### PR TITLE
filter null items within playlist

### DIFF
--- a/pages/api/spotify/users/[id]/items.ts
+++ b/pages/api/spotify/users/[id]/items.ts
@@ -111,7 +111,9 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
             }
 
             // Return data
-            const playlists: GetSpotifyPlaylist[] = allPlaylists.map(item => {
+            const playlists: GetSpotifyPlaylist[] = allPlaylists
+                .filter(item => item)
+                .map(item => {
                 return {
                     type: "spotify-playlist",
                     id: item.id,


### PR DESCRIPTION
Hello @jjdenhertog. First of all, great app, It was working perfectly until few days ago. 

Recently, when I click on "select playlist to import" for my spotify user, I get this error:

<img width="628" alt="Screenshot 2024-12-04 at 9 38 21 PM" src="https://github.com/user-attachments/assets/98ecbba5-bbcd-409d-9bb0-0b67fa462e53">

I did some debugging and realized that spotify is returning "null" items inside playlist.

<img width="1130" alt="Screenshot 2024-12-04 at 9 37 50 PM" src="https://github.com/user-attachments/assets/8c93e34e-a5e0-4b6b-85e3-5008c9e88ff0">

Then i found this thread:
https://community.spotify.com/t5/Spotify-for-Developers/null-values-when-using-quot-Get-Current-User-s-Playlists-quot/m-p/6550860#M15948

Looks like Spotify changed their API to return null for "spotify owned" playlist.

I understand this is not a complete fix to the problem. But, Until (if) you decide on a more permanent solution, I made a quick fix to filter these null playlist. If you are ok with the change, I would like to contribute this change as an appreciation to your time and effort to build the app. 