### PR TITLE
test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ memory
 
 __pycache__
 
+
 # Claude Flow generated files
 .claude/settings.local.json
 .mcp.json
@@ -134,5 +135,3 @@ claude-flow
 claude-flow.bat
 claude-flow.ps1
 hive-mind-prompt-*.txt
-
-test-results

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,10 @@ This project uses SPARC (Specification, Pseudocode, Architecture, Refinement, Co
 ## 🚀 Quick Setup
 
 ```bash
-# Add Claude Flow MCP server
+# Add MCP servers (Claude Flow required, others optional)
 claude mcp add claude-flow npx claude-flow@alpha mcp start
+claude mcp add ruv-swarm npx ruv-swarm mcp start  # Optional: Enhanced coordination
+claude mcp add flow-nexus npx flow-nexus@latest mcp start  # Optional: Cloud features
 ```
 
 ## MCP Tool Categories
@@ -161,6 +163,23 @@ claude mcp add claude-flow npx claude-flow@alpha mcp start
 
 ### System
 `benchmark_run`, `features_detect`, `swarm_monitor`
+
+### Flow-Nexus MCP Tools (Optional Advanced Features)
+Flow-Nexus extends MCP capabilities with 70+ cloud-based orchestration tools:
+
+**Key MCP Tool Categories:**
+- **Swarm & Agents**: `swarm_init`, `swarm_scale`, `agent_spawn`, `task_orchestrate`
+- **Sandboxes**: `sandbox_create`, `sandbox_execute`, `sandbox_upload` (cloud execution)
+- **Templates**: `template_list`, `template_deploy` (pre-built project templates)
+- **Neural AI**: `neural_train`, `neural_patterns`, `seraphina_chat` (AI assistant)
+- **GitHub**: `github_repo_analyze`, `github_pr_manage` (repository management)
+- **Real-time**: `execution_stream_subscribe`, `realtime_subscribe` (live monitoring)
+- **Storage**: `storage_upload`, `storage_list` (cloud file management)
+
+**Authentication Required:**
+- Register: `mcp__flow-nexus__user_register` or `npx flow-nexus@latest register`
+- Login: `mcp__flow-nexus__user_login` or `npx flow-nexus@latest login`
+- Access 70+ specialized MCP tools for advanced orchestration
 
 ## 🚀 Agent Execution Flow with Claude Code
 
@@ -319,6 +338,7 @@ Message 4: Write "file.js"
 
 - Documentation: https://github.com/ruvnet/claude-flow
 - Issues: https://github.com/ruvnet/claude-flow/issues
+- Flow-Nexus Platform: https://flow-nexus.ruv.io (registration required for cloud features)
 
 ---
 

--- a/apps/web/pages/api/logs.ts
+++ b/apps/web/pages/api/logs.ts
@@ -1,0 +1,35 @@
+import { generateError } from '@/helpers/errors/generateError';
+import { SyncLog } from '@spotify-to-plex/shared-types/common/sync';
+import { settingsDir } from '@spotify-to-plex/shared-utils/utils/settingsDir';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createRouter } from 'next-connect';
+
+const router = createRouter<NextApiRequest, NextApiResponse>()
+    .get(async (_req, res) => {
+        try {
+            // Get settings directory - matching sync-worker's approach
+            const logsPath = join(settingsDir, 'sync_log.json');
+            
+            // Return empty array if file doesn't exist (graceful handling)
+            if (!existsSync(logsPath)) {
+                return res.json([]);
+            }
+            
+            // Read and parse the logs file
+            const logsContent = readFileSync(logsPath, 'utf8');
+            const logs: SyncLog[] = JSON.parse(logsContent);
+            
+            res.json(logs);
+        } catch (error) {
+            console.error('Error reading sync logs:', error);
+            res.status(500).json({ error: 'Failed to read sync logs' });
+        }
+    });
+
+export default router.handler({
+    onError: (err: unknown, req: NextApiRequest, res: NextApiResponse) => {
+        generateError(req, res, "Logs", err);
+    }
+});

--- a/apps/web/src/components/Logs.tsx
+++ b/apps/web/src/components/Logs.tsx
@@ -1,7 +1,7 @@
 import { errorBoundary } from "@/helpers/errors/errorBoundary";
 import { Box, CircularProgress, Paper, Typography } from "@mui/material";
 import axios from "axios";
-import { SyncLog } from "cronjob/albums";
+import { SyncLog } from "@spotify-to-plex/shared-types/common/sync";
 import { useEffect, useState } from "react";
 import BMoment from "./BMoment";
 


### PR DESCRIPTION
The logs page at /spotify/logs is broken because it expects an API endpoint at /api/logs that doesn't exist. Fix this issue:

## The Problem:
- The Logs component fetches from `/api/logs` but this endpoint is missing
- The sync-worker creates logs in `sync_log.json` file but web app can't read them
- Component has wrong import: uses `cronjob/albums` instead of proper shared type

## Implementation:
1. Create `/api/logs.ts` endpoint that:
   - Reads sync_log.json from settings directory (like getSyncLogs does in sync-worker)
   - Returns empty array if file doesn't exist (graceful handling)
   - Uses proper error handling with generateError helper
   - Follows existing API patterns with next-connect router

2. Fix the Logs component import:
   - Change from `import { SyncLog } from "cronjob/albums"` 
   - To `import { SyncLog } from "@spotify-to-plex/shared-types/common/sync"`

3. Test that:
   - Page loads without error when no logs exist
   - Logs display correctly after running sync operations
   - No TypeScript or ESLint errors

This is a straightforward fix - just need to create the missing API endpoint and fix one import.

Acceptance Criteria:
- Logs page works without errors when no log file exists
- Logs display correctly when sync_log.json exists
- TypeScript and ESLint checks pass