### PR TITLE
bugfix: Spotify connected user playlists missing and duplicated

### DIFF
--- a/apps/web/pages/api/spotify/users/[id]/items.ts
+++ b/apps/web/pages/api/spotify/users/[id]/items.ts
@@ -70,7 +70,7 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
                 if (nextUrl) {
                     while (hasMoreResults) {
                         const loadMore = await api.currentUser.albums.savedAlbums(50, offset)
-                        allAlbums = allAlbums.concat(savedAlbumResult.items)
+                        allAlbums = allAlbums.concat(loadMore.items)
                         hasMoreResults = loadMore.offset + loadMore.limit < loadMore.total;
                         offset = loadMore.offset + loadMore.limit;
                     }
@@ -109,7 +109,7 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
             if (nextUrl) {
                 while (hasMoreResults) {
                     const loadMore = await api.currentUser.playlists.playlists(50, offset)
-                    allPlaylists = allPlaylists.concat(savedPlaylistResult.items)
+                    allPlaylists = allPlaylists.concat(loadMore.items)
                     hasMoreResults = loadMore.offset + loadMore.limit < loadMore.total;
                     offset = loadMore.offset + loadMore.limit;
                 }


### PR DESCRIPTION
I have a connection setup with my Spotify user, where I have 63 saved playlists. When viewing my user's playlists in the app, I see some duplicates, and a number of playlists don't show up at all.

When viewing the JSON response from `/api/spotify/users/<id>/items?type=playlists` for my user, it returns exactly 100 items, where every item appears twice.

I found that in `items.ts`, during the pagination queries, the original page is being append for every page, rather than each page's results