### PR TITLE
Add manual match support, and a fix for local files uploaded to spotify.

### DIFF
--- a/apps/web/pages/api/download/index.ts
+++ b/apps/web/pages/api/download/index.ts
@@ -1,5 +1,6 @@
 import { generateError } from '@/helpers/errors/generateError';
 import { TrackLink } from '@spotify-to-plex/shared-types/common/track';
+import { extractTrackId, isLocalTrack } from '@spotify-to-plex/shared-utils/spotify/extractTrackId';
 import { getStorageDir } from "@spotify-to-plex/shared-utils/utils/getStorageDir";
 
 import type { NextApiRequest, NextApiResponse } from 'next';
@@ -54,11 +55,17 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
                 default:
                 case "spotify":
                     res.send(trackIds.map(id => {
-                        const cleanId = id.replace('spotify:track:', '')
+                        // Skip local tracks - they cannot be shared as Spotify links
+                        if (isLocalTrack(id)) {
+                            return `(local track: ${id})`;
+                        }
+
+                        const cleanId = extractTrackId(id);
+                        if (!cleanId) return '';
 
                         return `https://open.spotify.com/track/${cleanId}`
 
-                    }).join('\n'))
+                    }).filter(item => item).join('\n'))
                     break;
             }
 

--- a/apps/web/pages/api/plex/cache-manual-match.ts
+++ b/apps/web/pages/api/plex/cache-manual-match.ts
@@ -1,0 +1,51 @@
+import { generateError } from '@/helpers/errors/generateError';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getStorageDir } from '@spotify-to-plex/shared-utils/utils/getStorageDir';
+import type { TrackLink } from '@spotify-to-plex/shared-types/common/track';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createRouter } from 'next-connect';
+
+const router = createRouter<NextApiRequest, NextApiResponse>()
+    .post(
+        async (req, res) => {
+            try {
+                const { spotifyId, title, artist, plexTrack } = req.body;
+
+                if (!spotifyId || !title || !artist || !plexTrack) {
+                    return res.status(400).json({ error: 'Missing required fields' });
+                }
+
+                // Read the existing cache
+                const path = join(getStorageDir(), 'track_links.json');
+                let allLinks: TrackLink[] = [];
+
+                if (existsSync(path)) {
+                    allLinks = JSON.parse(readFileSync(path, 'utf8'));
+                }
+
+                // Find or create the track link
+                let trackLink = allLinks.find(item => item.spotify_id === spotifyId);
+                if (!trackLink) {
+                    trackLink = { spotify_id: spotifyId };
+                    allLinks.push(trackLink);
+                }
+
+                // Add the plex_id (replace if it exists, since this is a manual selection)
+                trackLink.plex_id = [plexTrack.id];
+
+                // Write back to cache
+                writeFileSync(path, JSON.stringify(allLinks, undefined, 4));
+
+                res.status(200).json({ success: true });
+            } catch (error) {
+                res.status(500).json({ error: error instanceof Error ? error.message : 'Failed to cache manual match' });
+            }
+        })
+
+export default router.handler({
+    onError: (err: unknown, req: NextApiRequest, res: NextApiResponse) => {
+        console.log(err)
+        generateError(req, res, "Cache Manual Match", err);
+    }
+});

--- a/apps/web/pages/api/plex/manual-search.ts
+++ b/apps/web/pages/api/plex/manual-search.ts
@@ -10,11 +10,9 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
     .post(
         async (req, res) => {
             try {
-                const { query, trackTitle, albumTitle } = req.body;
+                const { query } = req.body;
 
-                const searchQuery = (query || trackTitle || albumTitle || '').trim();
-
-                if (!searchQuery)
+                if (!query || !query.trim())
                     return res.status(400).json({ message: "Please provide a search query" });
 
                 const settings = await getSettings();
@@ -23,24 +21,11 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
                     return res.status(400).json({ message: "No Plex connection found" });
 
                 // Search the Plex library using hub search
-                const results = await hubSearch(settings.uri, settings.token, searchQuery, 50);
+                const results = await hubSearch(settings.uri, settings.token, query, 50);
 
                 // Filter to only include tracks and convert to PlexTrack format
-                const normalizedQuery = searchQuery.toLowerCase();
-                const normalizedAlbumTitle = (albumTitle || '').toLowerCase();
-
                 const trackResults: PlexTrack[] = results
                     .filter(result => result.type === 'track')
-                    .filter((result: any) => {
-                        const title = (result.title || '').toLowerCase();
-                        const album = (result.album?.title || '').toLowerCase();
-
-                        const titleMatch = normalizedQuery ? title.includes(normalizedQuery) : false;
-                        const albumMatch = normalizedQuery ? album.includes(normalizedQuery) : false;
-                        const explicitAlbumMatch = normalizedAlbumTitle ? album.includes(normalizedAlbumTitle) : false;
-
-                        return titleMatch || albumMatch || explicitAlbumMatch;
-                    })
                     .map((result: any) => ({
                         guid: result.guid || '',
                         id: result.id || result.ratingKey || '',

--- a/apps/web/pages/api/plex/manual-search.ts
+++ b/apps/web/pages/api/plex/manual-search.ts
@@ -10,9 +10,11 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
     .post(
         async (req, res) => {
             try {
-                const { query } = req.body;
+                const { query, trackTitle, albumTitle } = req.body;
 
-                if (!query || !query.trim())
+                const searchQuery = (query || trackTitle || albumTitle || '').trim();
+
+                if (!searchQuery)
                     return res.status(400).json({ message: "Please provide a search query" });
 
                 const settings = await getSettings();
@@ -21,11 +23,24 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
                     return res.status(400).json({ message: "No Plex connection found" });
 
                 // Search the Plex library using hub search
-                const results = await hubSearch(settings.uri, settings.token, query, 50);
+                const results = await hubSearch(settings.uri, settings.token, searchQuery, 50);
 
                 // Filter to only include tracks and convert to PlexTrack format
+                const normalizedQuery = searchQuery.toLowerCase();
+                const normalizedAlbumTitle = (albumTitle || '').toLowerCase();
+
                 const trackResults: PlexTrack[] = results
                     .filter(result => result.type === 'track')
+                    .filter((result: any) => {
+                        const title = (result.title || '').toLowerCase();
+                        const album = (result.album?.title || '').toLowerCase();
+
+                        const titleMatch = normalizedQuery ? title.includes(normalizedQuery) : false;
+                        const albumMatch = normalizedQuery ? album.includes(normalizedQuery) : false;
+                        const explicitAlbumMatch = normalizedAlbumTitle ? album.includes(normalizedAlbumTitle) : false;
+
+                        return titleMatch || albumMatch || explicitAlbumMatch;
+                    })
                     .map((result: any) => ({
                         guid: result.guid || '',
                         id: result.id || result.ratingKey || '',

--- a/apps/web/pages/api/plex/manual-search.ts
+++ b/apps/web/pages/api/plex/manual-search.ts
@@ -1,0 +1,62 @@
+import { generateError } from '@/helpers/errors/generateError';
+import { getSettings } from '@spotify-to-plex/plex-config/functions/getSettings';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createRouter } from 'next-connect';
+import type { PlexTrack } from '@spotify-to-plex/plex-music-search/types/PlexTrack';
+import hubSearch from '@spotify-to-plex/plex-music-search/actions/hubSearch';
+import type { HubSearchResult } from '@spotify-to-plex/plex-music-search/types/actions/HubSearchResult';
+
+const router = createRouter<NextApiRequest, NextApiResponse>()
+    .post(
+        async (req, res) => {
+            try {
+                const { query } = req.body;
+
+                if (!query || !query.trim())
+                    return res.status(400).json({ message: "Please provide a search query" });
+
+                const settings = await getSettings();
+
+                if (!settings.uri || !settings.token)
+                    return res.status(400).json({ message: "No Plex connection found" });
+
+                // Search the Plex library using hub search
+                const results = await hubSearch(settings.uri, settings.token, query, 50);
+
+                // Filter to only include tracks and convert to PlexTrack format
+                const trackResults: PlexTrack[] = results
+                    .filter(result => result.type === 'track')
+                    .map((result: any) => ({
+                        guid: result.guid || '',
+                        id: result.id || result.ratingKey || '',
+                        source: result.src || '',
+                        artist: {
+                            id: result.artist?.id || '',
+                            title: result.artist?.title || '',
+                            guid: result.artist?.guid || '',
+                            image: result.artist?.image || ''
+                        },
+                        album: result.album ? {
+                            id: result.album.id || '',
+                            title: result.album.title || '',
+                            guid: result.album.guid || '',
+                            image: result.album.image || ''
+                        } : undefined,
+                        title: result.title || '',
+                        image: result.image || '',
+                        src: result.src || ''
+                    }));
+
+                return res.json(trackResults);
+            } catch (error) {
+                console.error('Error performing manual Plex search:', error);
+
+                return res.status(500).json({ message: "Something went wrong while searching the Plex library." })
+            }
+        })
+
+export default router.handler({
+    onError: (err: unknown, req: NextApiRequest, res: NextApiResponse) => {
+        generateError(req, res, "Manual Search", err);
+    }
+});

--- a/apps/web/pages/api/spotify/track.ts
+++ b/apps/web/pages/api/spotify/track.ts
@@ -1,5 +1,6 @@
 import { generateError } from '@/helpers/errors/generateError';
 import { Track } from '@spotify-to-plex/shared-types/spotify/Track';
+import { extractTrackId } from '@spotify-to-plex/shared-utils/spotify/extractTrackId';
 import { SpotifyApi } from '@spotify/web-api-ts-sdk';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createRouter } from 'next-connect';
@@ -33,7 +34,11 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
                 return res.status(400).json({ error: "Invalid Spotify URI, expecting spotify:track:id" })
 
             const api = SpotifyApi.withClientCredentials(process.env.SPOTIFY_API_CLIENT_ID, process.env.SPOTIFY_API_CLIENT_SECRET);
-            const trackId = id.slice(Math.max(0, id.indexOf('spotify:track:') + 'spotify:track:'.length)).trim();
+            const trackId = extractTrackId(id);
+
+            if (!trackId)
+                return res.status(400).json({ error: "Invalid track ID" })
+
             const data = await api.tracks.get(trackId)
             if (!data)
                 return res.status(400).json({ error: "No data found, double check your Spotify Track URI" })

--- a/apps/web/pages/api/spotify/tracks/[id].ts
+++ b/apps/web/pages/api/spotify/tracks/[id].ts
@@ -1,5 +1,6 @@
 import { generateError } from '@/helpers/errors/generateError';
 import { Track } from '@spotify-to-plex/shared-types/spotify/Track';
+import { extractTrackId, isLocalTrack } from '@spotify-to-plex/shared-utils/spotify/extractTrackId';
 import { SpotifyApi } from '@spotify/web-api-ts-sdk';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createRouter } from 'next-connect';
@@ -17,10 +18,15 @@ const router = createRouter<NextApiRequest, NextApiResponse>()
             if (!process.env.SPOTIFY_API_CLIENT_ID || !process.env.SPOTIFY_API_CLIENT_SECRET)
                 return res.status(400).json({ error: "Spotify Credentials missing. Please add the environment variables to use this feature." })
 
-            // Extract track ID from Spotify URI if needed
-            const trackId = id.startsWith('spotify:track:')
-                ? id.replace('spotify:track:', '')
-                : id;
+            // Check if it's a local track
+            if (isLocalTrack(id)) {
+                return res.status(400).json({ error: "Local Spotify tracks cannot be looked up via API" })
+            }
+
+            // Extract track ID from Spotify URI
+            const trackId = extractTrackId(id);
+            if (!trackId)
+                return res.status(400).json({ error: "Invalid track ID" })
 
             try {
                 const api = SpotifyApi.withClientCredentials(process.env.SPOTIFY_API_CLIENT_ID, process.env.SPOTIFY_API_CLIENT_SECRET);

--- a/apps/web/src/components/ManualSearchPopup.tsx
+++ b/apps/web/src/components/ManualSearchPopup.tsx
@@ -1,0 +1,189 @@
+import { Box, Button, CircularProgress, FormControlLabel, ListItem, Radio, RadioGroup, TextField, Typography, Divider } from "@mui/material";
+import axios from "axios";
+import { ChangeEvent, useCallback, useState } from "react";
+import type { PlexTrack } from "@spotify-to-plex/plex-music-search/types/PlexTrack";
+
+type Props = {
+    readonly trackTitle: string;
+    readonly artistNames: string[];
+    readonly onClose: () => void;
+    readonly onSelect: (track: PlexTrack) => void;
+}
+
+export default function ManualSearchPopup(props: Props) {
+    const { trackTitle, artistNames, onClose, onSelect } = props;
+
+    const [searchQuery, setSearchQuery] = useState<string>(`${artistNames[0] || ''} ${trackTitle}`.trim());
+    const [loading, setLoading] = useState<boolean>(false);
+    const [results, setResults] = useState<PlexTrack[]>([]);
+    const [selectedIdx, setSelectedIdx] = useState<number>(0);
+    const [error, setError] = useState<string>('');
+
+    const thumbSize = typeof window !== 'undefined' && window.innerWidth < 400 ? 50 : 80;
+
+    const onSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+        setSearchQuery(e.currentTarget.value);
+    }, []);
+
+    const onSearch = useCallback(async () => {
+        if (!searchQuery.trim()) {
+            setError('Please enter a search query');
+            return;
+        }
+
+        setLoading(true);
+        setError('');
+        setResults([]);
+
+        try {
+            const response = await axios.post<PlexTrack[]>('/api/plex/manual-search', {
+                query: searchQuery
+            });
+
+            if (response.data && response.data.length > 0) {
+                setResults(response.data);
+                setSelectedIdx(0);
+            } else {
+                setError('No tracks found. Try a different search.');
+            }
+        } catch (err) {
+            console.error('Error searching:', err);
+            setError('Failed to search the Plex library. Please try again.');
+        } finally {
+            setLoading(false);
+        }
+    }, [searchQuery]);
+
+    const onSelectTrack = useCallback(() => {
+        if (results[selectedIdx]) {
+            onSelect(results[selectedIdx]);
+            onClose();
+        }
+    }, [results, selectedIdx, onClose, onSelect]);
+
+    const onRadioChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+        setSelectedIdx(Number(e.currentTarget.value));
+    }, []);
+
+    const handleKeyPress = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            onSearch();
+        }
+    }, [onSearch]);
+
+    return (
+        <Box sx={{ p: 2, display: 'flex', flexDirection: 'column', gap: 2 }}>
+            <Box>
+                <Typography variant="h6" sx={{ mb: 1 }}>Manual Track Search</Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    Search for <strong>{trackTitle}</strong> by {artistNames.join(', ')}
+                </Typography>
+            </Box>
+
+            <Box sx={{ display: 'flex', gap: 1 }}>
+                <TextField
+                    fullWidth
+                    size="small"
+                    placeholder="Search artist, title, album..."
+                    value={searchQuery}
+                    onChange={onSearchChange}
+                    onKeyPress={handleKeyPress}
+                    disabled={loading}
+                />
+                <Button
+                    variant="contained"
+                    onClick={onSearch}
+                    disabled={loading || !searchQuery.trim()}
+                >
+                    {loading ? <CircularProgress size={24} /> : 'Search'}
+                </Button>
+            </Box>
+
+            {error && (
+                <Typography variant="body2" color="error">
+                    {error}
+                </Typography>
+            )}
+
+            {results.length > 0 && (
+                <Box sx={{ maxHeight: 400, overflow: 'auto', border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+                    <RadioGroup value={`${selectedIdx}`} onChange={onRadioChange}>
+                        {results.map((track, index) => {
+                            const thumbUrl = track.image && track.image.indexOf('rovicorp') === -1 ? `/api/plex/image?path=${track.image}` : '';
+
+                            return (
+                                <ListItem
+                                    key={`manual-search-${track.id}-${index}`}
+                                    sx={{
+                                        p: 1,
+                                        borderBottom: index < results.length - 1 ? '1px solid' : 'none',
+                                        borderColor: 'divider',
+                                        cursor: 'pointer',
+                                        '&:hover': {
+                                            bgcolor: 'action.hover'
+                                        }
+                                    }}
+                                >
+                                    <FormControlLabel
+                                        value={`${index}`}
+                                        control={<Radio checked={selectedIdx === index} />}
+                                        label={
+                                            <Box display="flex" gap={1} width="100%">
+                                                <Box
+                                                    width={thumbSize}
+                                                    height={thumbSize}
+                                                    position="relative"
+                                                    flexShrink={0}
+                                                >
+                                                    {thumbUrl && (
+                                                        <img
+                                                            src={thumbUrl}
+                                                            alt={track.title}
+                                                            width={thumbSize}
+                                                            height={thumbSize}
+                                                            style={{ borderRadius: 4 }}
+                                                        />
+                                                    )}
+                                                </Box>
+                                                <Box sx={{ minWidth: 0 }}>
+                                                    <Typography display="block" variant="body1" sx={{ wordBreak: 'break-word' }}>
+                                                        {track.title}
+                                                    </Typography>
+                                                    <Typography display="block" variant="body2" color="text.secondary">
+                                                        {track.artist?.title || 'Unknown Artist'}
+                                                    </Typography>
+                                                    {track.album && (
+                                                        <Typography display="block" variant="body2" color="text.secondary">
+                                                            {track.album.title}
+                                                        </Typography>
+                                                    )}
+                                                </Box>
+                                            </Box>
+                                        }
+                                        sx={{ width: '100%' }}
+                                    />
+                                </ListItem>
+                            );
+                        })}
+                    </RadioGroup>
+                </Box>
+            )}
+
+            <Divider />
+
+            <Box sx={{ display: 'flex', gap: 1, justifyContent: 'flex-end' }}>
+                <Button variant="outlined" onClick={onClose}>
+                    Cancel
+                </Button>
+                <Button
+                    variant="contained"
+                    onClick={onSelectTrack}
+                    disabled={results.length === 0 || loading}
+                >
+                    Select Track
+                </Button>
+            </Box>
+        </Box>
+    );
+}

--- a/apps/web/src/components/ManualSearchPopup.tsx
+++ b/apps/web/src/components/ManualSearchPopup.tsx
@@ -6,13 +6,12 @@ import type { PlexTrack } from "@spotify-to-plex/plex-music-search/types/PlexTra
 type Props = {
     readonly trackTitle: string;
     readonly artistNames: string[];
-    readonly albumName?: string;
     readonly onClose: () => void;
     readonly onSelect: (track: PlexTrack) => void;
 }
 
 export default function ManualSearchPopup(props: Props) {
-    const { trackTitle, artistNames, albumName, onClose, onSelect } = props;
+    const { trackTitle, artistNames, onClose, onSelect } = props;
 
     const [searchQuery, setSearchQuery] = useState<string>(`${artistNames[0] || ''} ${trackTitle}`.trim());
     const [loading, setLoading] = useState<boolean>(false);
@@ -79,7 +78,6 @@ export default function ManualSearchPopup(props: Props) {
                 <Typography variant="h6" sx={{ mb: 1 }}>Manual Track Search</Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                     Search for <strong>{trackTitle}</strong> by {artistNames.join(', ')}
-                    {albumName && <> from <strong>{albumName}</strong></>}
                 </Typography>
             </Box>
 
@@ -101,20 +99,6 @@ export default function ManualSearchPopup(props: Props) {
                     {loading ? <CircularProgress size={24} /> : 'Search'}
                 </Button>
             </Box>
-
-            {albumName && (
-                <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() => {
-                        setSearchQuery(albumName);
-                        setTimeout(() => onSearch(), 0);
-                    }}
-                    disabled={loading}
-                >
-                    Search by Album
-                </Button>
-            )}
 
             {error && (
                 <Typography variant="body2" color="error">

--- a/apps/web/src/components/ManualSearchPopup.tsx
+++ b/apps/web/src/components/ManualSearchPopup.tsx
@@ -14,7 +14,7 @@ type Props = {
 export default function ManualSearchPopup(props: Props) {
     const { trackTitle, artistNames, albumName, onClose, onSelect } = props;
 
-    const [searchQuery, setSearchQuery] = useState<string>(`${artistNames[0] || ''} ${trackTitle}`.trim());
+    const [searchQuery, setSearchQuery] = useState<string>(trackTitle.trim());
     const [loading, setLoading] = useState<boolean>(false);
     const [results, setResults] = useState<PlexTrack[]>([]);
     const [selectedIdx, setSelectedIdx] = useState<number>(0);
@@ -38,7 +38,9 @@ export default function ManualSearchPopup(props: Props) {
 
         try {
             const response = await axios.post<PlexTrack[]>('/api/plex/manual-search', {
-                query: searchQuery
+                query: searchQuery,
+                trackTitle,
+                albumTitle: albumName
             });
 
             if (response.data && response.data.length > 0) {
@@ -101,20 +103,6 @@ export default function ManualSearchPopup(props: Props) {
                     {loading ? <CircularProgress size={24} /> : 'Search'}
                 </Button>
             </Box>
-
-            {albumName && (
-                <Button
-                    variant="outlined"
-                    size="small"
-                    onClick={() => {
-                        setSearchQuery(albumName);
-                        setTimeout(() => onSearch(), 0);
-                    }}
-                    disabled={loading}
-                >
-                    Search by Album
-                </Button>
-            )}
 
             {error && (
                 <Typography variant="body2" color="error">

--- a/apps/web/src/components/ManualSearchPopup.tsx
+++ b/apps/web/src/components/ManualSearchPopup.tsx
@@ -14,7 +14,7 @@ type Props = {
 export default function ManualSearchPopup(props: Props) {
     const { trackTitle, artistNames, albumName, onClose, onSelect } = props;
 
-    const [searchQuery, setSearchQuery] = useState<string>(trackTitle.trim());
+    const [searchQuery, setSearchQuery] = useState<string>(`${artistNames[0] || ''} ${trackTitle}`.trim());
     const [loading, setLoading] = useState<boolean>(false);
     const [results, setResults] = useState<PlexTrack[]>([]);
     const [selectedIdx, setSelectedIdx] = useState<number>(0);
@@ -38,9 +38,7 @@ export default function ManualSearchPopup(props: Props) {
 
         try {
             const response = await axios.post<PlexTrack[]>('/api/plex/manual-search', {
-                query: searchQuery,
-                trackTitle,
-                albumTitle: albumName
+                query: searchQuery
             });
 
             if (response.data && response.data.length > 0) {
@@ -103,6 +101,20 @@ export default function ManualSearchPopup(props: Props) {
                     {loading ? <CircularProgress size={24} /> : 'Search'}
                 </Button>
             </Box>
+
+            {albumName && (
+                <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => {
+                        setSearchQuery(albumName);
+                        setTimeout(() => onSearch(), 0);
+                    }}
+                    disabled={loading}
+                >
+                    Search by Album
+                </Button>
+            )}
 
             {error && (
                 <Typography variant="body2" color="error">

--- a/apps/web/src/components/ManualSearchPopup.tsx
+++ b/apps/web/src/components/ManualSearchPopup.tsx
@@ -6,12 +6,13 @@ import type { PlexTrack } from "@spotify-to-plex/plex-music-search/types/PlexTra
 type Props = {
     readonly trackTitle: string;
     readonly artistNames: string[];
+    readonly albumName?: string;
     readonly onClose: () => void;
     readonly onSelect: (track: PlexTrack) => void;
 }
 
 export default function ManualSearchPopup(props: Props) {
-    const { trackTitle, artistNames, onClose, onSelect } = props;
+    const { trackTitle, artistNames, albumName, onClose, onSelect } = props;
 
     const [searchQuery, setSearchQuery] = useState<string>(`${artistNames[0] || ''} ${trackTitle}`.trim());
     const [loading, setLoading] = useState<boolean>(false);
@@ -78,6 +79,7 @@ export default function ManualSearchPopup(props: Props) {
                 <Typography variant="h6" sx={{ mb: 1 }}>Manual Track Search</Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                     Search for <strong>{trackTitle}</strong> by {artistNames.join(', ')}
+                    {albumName && <> from <strong>{albumName}</strong></>}
                 </Typography>
             </Box>
 
@@ -99,6 +101,20 @@ export default function ManualSearchPopup(props: Props) {
                     {loading ? <CircularProgress size={24} /> : 'Search'}
                 </Button>
             </Box>
+
+            {albumName && (
+                <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={() => {
+                        setSearchQuery(albumName);
+                        setTimeout(() => onSearch(), 0);
+                    }}
+                    disabled={loading}
+                >
+                    Search by Album
+                </Button>
+            )}
 
             {error && (
                 <Typography variant="body2" color="error">

--- a/apps/web/src/components/MissingTrack.tsx
+++ b/apps/web/src/components/MissingTrack.tsx
@@ -1,6 +1,7 @@
 import { GetTidalTracksResponse } from "@/pages/api/tidal";
 import { Alert, Box, Button, Divider, Typography } from "@mui/material";
 import { Track } from "@spotify-to-plex/shared-types/spotify/Track";
+import { extractTrackId, isLocalTrack } from "@spotify-to-plex/shared-utils/spotify/extractTrackId";
 import axios from "axios";
 import { forwardRef, useCallback, useImperativeHandle, useMemo, useRef, useState } from "react";
 
@@ -216,10 +217,10 @@ const MissingTrack = forwardRef<MissingTrackHandle, MissingTrackProps>((props, r
     }, [sendToSlskd]);
 
 
-    const spotifyId = useMemo(()=>{
+    const spotifyId = useMemo(() => {
         if (!track.id) return null;
 
-        return track.id.replace('spotify:track:', '');
+        return extractTrackId(track.id);
     }, [track.id]);
 
     return (
@@ -283,7 +284,7 @@ const MissingTrack = forwardRef<MissingTrackHandle, MissingTrackProps>((props, r
                     )}
 
                     {/* Spotify Button */}
-                    {!!spotifyId && 
+                    {!!spotifyId &&
                         <Box>
                             <Button
                                 component="a"

--- a/apps/web/src/components/PlexPlaylist.tsx
+++ b/apps/web/src/components/PlexPlaylist.tsx
@@ -234,6 +234,34 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
         }
     }, [trackSelections])
 
+    ///////////////////////////////////
+    // Handle manual track selection
+    ///////////////////////////////////
+    const onManualTrackSelect = useCallback((spotifyTrack: GetSpotifyPlaylist['tracks'][0] | GetSpotifyAlbum['tracks'][0], plexTrack: SearchResponse['result'][0]) => {
+        // Create a synthetic search response with the manually selected track
+        const artist = spotifyTrack.artists[0];
+        const searchResponse: SearchResponse = {
+            id: spotifyTrack.id,
+            title: spotifyTrack.title,
+            artist: artist,
+            result: [plexTrack]
+        };
+
+        // Update tracks with the manual selection
+        setTracks(prevTracks =>
+            prevTracks.map(track =>
+                track.id === spotifyTrack.id ? searchResponse : track
+            )
+        );
+
+        // Set the selection to index 0 (the only result)
+        if (artist) {
+            onSetSongIndex(artist, spotifyTrack.title, 0);
+        }
+
+        enqueueSnackbar(`${spotifyTrack.title} manually matched`, { variant: 'success' });
+    }, [onSetSongIndex]);
+
     ///////////////////////////////////////////////
     // Modify Playlist name
     ///////////////////////////////////////////////
@@ -482,7 +510,11 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
                     const songIdx = trackSelectIdx ? trackSelectIdx.idx : 0;
                     const loading = loadingTracks && !(tracksLoaded.some(item => item === track.id))
 
-                    return <PlexTrack key={`${playlist.id}-plex-${track.title}-${track.id}}`} loading={loading} track={track} setSongIdx={onSetSongIndex} songIdx={songIdx} data={data} />
+                    const handleManualSelect = (plexTrack: SearchResponse['result'][0]) => {
+                        onManualTrackSelect(track, plexTrack);
+                    }
+
+                    return <PlexTrack key={`${playlist.id}-plex-${track.title}-${track.id}}`} loading={loading} track={track} setSongIdx={onSetSongIndex} songIdx={songIdx} data={data} onManualSelect={handleManualSelect} />
                 })}
             </Stack>
         </Paper>

--- a/apps/web/src/components/PlexPlaylist.tsx
+++ b/apps/web/src/components/PlexPlaylist.tsx
@@ -318,12 +318,16 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
             items: []
         }
 
-        for (let i = 0; i < tracks.length; i++) {
-            const item = tracks[i];
+        for (let i = 0; i < playlist.tracks.length; i++) {
+            const playlistTrack = playlist.tracks[i];
+            if (!playlistTrack)
+                continue;
+
+            const item = tracks.find(track => track.id === playlistTrack.id);
             if (!item)
                 continue;
 
-            const trackSelectIdx = trackSelections.find(selectionItem => selectionItem.artist === item?.artist && selectionItem.title === item?.title)
+            const trackSelectIdx = trackSelections.find(selectionItem => selectionItem.trackId === item.id)
             const song = item.result?.[trackSelectIdx ? trackSelectIdx.idx : 0];
 
             if (song)

--- a/apps/web/src/components/PlexPlaylist.tsx
+++ b/apps/web/src/components/PlexPlaylist.tsx
@@ -23,6 +23,7 @@ export type PlexPlaylistProps = {
 type TrackSelection = {
     artist: string
     title: string
+    trackId: string
     idx: number
 }
 
@@ -219,18 +220,18 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
     ///////////////////////////////////
     // Set selected track index
     ///////////////////////////////////
-    const onSetSongIndex = useCallback((artist: string, track: string, idx: number) => {
-        console.log('onSetSongIndex', artist, track, idx)
-        if (trackSelections.some(item => item.artist === artist && item.title === track)) {
+    const onSetSongIndex = useCallback((artist: string, track: string, trackId: string, idx: number) => {
+        console.log('onSetSongIndex', artist, track, trackId, idx)
+        if (trackSelections.some(item => item.trackId === trackId)) {
 
             setTrackSelections(items => items.map(item => {
-                if (item.artist === artist && item.title === track)
+                if (item.trackId === trackId)
                     return { ...item, idx }
 
                 return item;
             }))
         } else {
-            setTrackSelections(prev => [...prev, { artist, title: track, idx }])
+            setTrackSelections(prev => [...prev, { artist, title: track, trackId, idx }])
         }
     }, [trackSelections])
 
@@ -256,7 +257,7 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
 
         // Set the selection to index 0 (the only result)
         if (artist) {
-            onSetSongIndex(artist, spotifyTrack.title, 0);
+            onSetSongIndex(artist, spotifyTrack.title, spotifyTrack.id, 0);
         }
 
         // Cache the manual selection so it persists across runs
@@ -516,7 +517,7 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
                         return track.artists.indexOf(item.artist) > -1 && track.title === item.title
 
                     })
-                    const trackSelectIdx = trackSelections.find(item => track.artists.indexOf(item.artist) > -1 && item.title === track.title)
+                    const trackSelectIdx = trackSelections.find(item => item.trackId === track.id)
                     const songIdx = trackSelectIdx ? trackSelectIdx.idx : 0;
                     const loading = loadingTracks && !(tracksLoaded.some(item => item === track.id))
 

--- a/apps/web/src/components/PlexPlaylist.tsx
+++ b/apps/web/src/components/PlexPlaylist.tsx
@@ -259,6 +259,16 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
             onSetSongIndex(artist, spotifyTrack.title, 0);
         }
 
+        // Cache the manual selection so it persists across runs
+        axios.post('/api/plex/cache-manual-match', {
+            spotifyId: spotifyTrack.id,
+            title: spotifyTrack.title,
+            artist: artist,
+            plexTrack: plexTrack
+        }).catch(error => {
+            console.error('Failed to cache manual match:', error);
+        });
+
         enqueueSnackbar(`${spotifyTrack.title} manually matched`, { variant: 'success' });
     }, [onSetSongIndex]);
 

--- a/apps/web/src/components/PlexTrack.tsx
+++ b/apps/web/src/components/PlexTrack.tsx
@@ -15,7 +15,7 @@ type Props = {
     }
     readonly data?: SearchResponse
     readonly songIdx: number
-    readonly setSongIdx?: (artist: string, name: string, idx: number) => void
+    readonly setSongIdx?: (artist: string, name: string, trackId: string, idx: number) => void
     readonly onManualSelect?: (track: PlexTrackType) => void
 }
 export default function PlexTrack(props: Props) {
@@ -88,9 +88,9 @@ export default function PlexTrack(props: Props) {
 
         const songIdx = Number(e.currentTarget.value)
         if (setSongIdx && artistNames[0])
-            setSongIdx(artistNames[0], trackTitle, songIdx)
+            setSongIdx(artistNames[0], trackTitle, id, songIdx)
 
-    }, [artistNames, setSongIdx, trackTitle])
+    }, [artistNames, setSongIdx, trackTitle, id])
 
     ////////////////////////////////////
     // Handle not perfect songs

--- a/apps/web/src/components/PlexTrack.tsx
+++ b/apps/web/src/components/PlexTrack.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable custom/jsx-single-line-props */
 import type { SearchResponse } from "@spotify-to-plex/plex-music-search/types/SearchResponse";
-import type { PlexTrack } from "@spotify-to-plex/plex-music-search/types/PlexTrack";
-import { Check, LibraryMusicSharp, Warning } from "@mui/icons-material";
-import { Box, CircularProgress, Divider, FormControlLabel, IconButton, ListItem, Paper, Radio, RadioGroup, Tooltip, Typography } from "@mui/material";
+import type { PlexTrack as PlexTrackType } from "@spotify-to-plex/plex-music-search/types/PlexTrack";
+import { Check, LibraryMusicSharp, Warning, Edit } from "@mui/icons-material";
+import { Box, CircularProgress, Divider, FormControlLabel, IconButton, ListItem, Modal, Paper, Radio, RadioGroup, Tooltip, Typography } from "@mui/material";
 import { ChangeEvent, useCallback, useMemo, useState } from "react";
+import ManualSearchPopup from "./ManualSearchPopup";
 type Props = {
     readonly loading: boolean
     readonly track: {
@@ -15,17 +16,18 @@ type Props = {
     readonly data?: SearchResponse
     readonly songIdx: number
     readonly setSongIdx?: (artist: string, name: string, idx: number) => void
+    readonly onManualSelect?: (track: PlexTrackType) => void
 }
 export default function PlexTrack(props: Props) {
 
-    const { loading, track, data, songIdx, setSongIdx } = props;
+    const { loading, track, data, songIdx, setSongIdx, onManualSelect } = props;
 
     const songs = useMemo(() => {
 
         if (!data)
             return []
 
-        return data.result.map((item: PlexTrack) => {
+        return data.result.map((item: PlexTrackType) => {
             const thumbUrl = item.image && item.image.indexOf('rovicorp') === -1 ? `/api/plex/image?path=${item.image}` : '';
             const albumThumbUrl = item.album?.image && item.image.indexOf('rovicorp') === -1 ? `/api/plex/image?path=${item.album.image}` : '';
 
@@ -56,6 +58,23 @@ export default function PlexTrack(props: Props) {
 
 
     const thumbSize = window.innerWidth < 400 ? 50 : 80;
+
+    ////////////////////////////////////
+    // Handle manual search
+    ////////////////////////////////////
+    const [showManualSearch, setShowManualSearch] = useState(false);
+    const onShowManualSearchClick = useCallback(() => {
+        setShowManualSearch(true);
+    }, []);
+    const onCloseManualSearch = useCallback(() => {
+        setShowManualSearch(false);
+    }, []);
+    const onManualSelectTrack = useCallback((track: PlexTrackType) => {
+        if (onManualSelect) {
+            onManualSelect(track);
+        }
+        setShowManualSearch(false);
+    }, [onManualSelect]);
 
     ////////////////////////////////////
     // Handle multiple song results
@@ -108,9 +127,14 @@ export default function PlexTrack(props: Props) {
                         </>
                     }
                     {!!data && data.result.length === 0 &&
-                        <Tooltip title="Song not found">
-                            <IconButton size="small" color="warning" onClick={onNotPerfectMatchClick}><Warning sx={{ fontSize: '1em' }} /></IconButton>
-                        </Tooltip>
+                        <>
+                            <Tooltip title="Manual match">
+                                <IconButton size="small" color="warning" onClick={onShowManualSearchClick}><Edit sx={{ fontSize: '1em' }} /></IconButton>
+                            </Tooltip>
+                            <Tooltip title="Song not found">
+                                <IconButton size="small" color="warning" onClick={onNotPerfectMatchClick}><Warning sx={{ fontSize: '1em' }} /></IconButton>
+                            </Tooltip>
+                        </>
                     }
                 </>}
             </Box>
@@ -129,7 +153,7 @@ export default function PlexTrack(props: Props) {
                             py: 1
                         }}
                     >
-                        
+
                         <FormControlLabel
                             value={`${index}`}
                             control={<Radio checked={songIdx === index} />}
@@ -159,5 +183,30 @@ export default function PlexTrack(props: Props) {
             </RadioGroup>
         </Box>}
         <Divider sx={{ mt: 1, mb: 1 }} />
+
+        {!!showManualSearch && (
+            <Modal open onClose={onCloseManualSearch}>
+                <Box sx={{
+                    position: 'absolute',
+                    top: '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                    width: '90%',
+                    maxWidth: 600,
+                    maxHeight: '90vh',
+                    overflow: 'auto',
+                    bgcolor: 'background.paper',
+                    borderRadius: 1,
+                    boxShadow: 24
+                }}>
+                    <ManualSearchPopup
+                        trackTitle={trackTitle}
+                        artistNames={artistNames}
+                        onClose={onCloseManualSearch}
+                        onSelect={onManualSelectTrack}
+                    />
+                </Box>
+            </Modal>
+        )}
     </Box>)
 }

--- a/apps/web/src/components/PlexTrack.tsx
+++ b/apps/web/src/components/PlexTrack.tsx
@@ -105,10 +105,28 @@ export default function PlexTrack(props: Props) {
 
     return (<Box>
         <Paper elevation={0} sx={{ p: 1, mb: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1, bgcolor: 'action.hover' }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <Box>
-                    <Typography variant="body1">{trackTitle}</Typography>
-                    <Typography variant="caption">{artistNames.join(', ')}</Typography>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, minWidth: 0 }}>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5, flexWrap: 'wrap' }}>
+                        <img src="/img/spotify.png" alt="Spotify" style={{ width: 16, height: 16 }} />
+                        <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                            {trackTitle} - <strong>{artistNames.join(', ')}</strong>
+                        </Typography>
+                        <Typography variant="caption" sx={{ color: 'text.secondary', ml: 'auto' }}>
+                            (From Spotify)
+                        </Typography>
+                    </Box>
+                    {!!songs[songIdx] && (
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }}>
+                            <img src="/img/plex.png" alt="Plex" style={{ width: 16, height: 16 }} />
+                            <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                                {songs[songIdx].trackTitle} - <strong>{songs[songIdx].artistName}</strong>
+                            </Typography>
+                            <Typography variant="caption" sx={{ color: 'text.secondary', ml: 'auto' }}>
+                                (Matched in Plex)
+                            </Typography>
+                        </Box>
+                    )}
                 </Box>
             </Box>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -171,9 +189,13 @@ export default function PlexTrack(props: Props) {
                                         />}
                                 </Box>
                                 <Box>
-                                    <Typography display="block" variant="body1">{song.trackTitle}</Typography>
-                                    <Typography display="block" variant="body2">{song.artistName}</Typography>
-                                    {!!song.album && <Typography display="block" variant="body2">{song.album.title}</Typography>}
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
+                                        <img src="/img/plex.png" alt="Plex" style={{ width: 14, height: 14 }} />
+                                        <Typography display="block" variant="body1">
+                                            {song.trackTitle} - <strong>{song.artistName}</strong>
+                                        </Typography>
+                                    </Box>
+                                    {!!song.album && <Typography display="block" variant="caption">{song.album.title}</Typography>}
                                 </Box>
                             </Box>
                             }

--- a/apps/web/src/components/PlexTrack.tsx
+++ b/apps/web/src/components/PlexTrack.tsx
@@ -12,6 +12,7 @@ type Props = {
         artists: string[];
         title: string;
         reason?: string;
+        album?: string;
     }
     readonly data?: SearchResponse
     readonly songIdx: number
@@ -202,6 +203,7 @@ export default function PlexTrack(props: Props) {
                     <ManualSearchPopup
                         trackTitle={trackTitle}
                         artistNames={artistNames}
+                        albumName={track.album}
                         onClose={onCloseManualSearch}
                         onSelect={onManualSelectTrack}
                     />

--- a/apps/web/src/components/PlexTrack.tsx
+++ b/apps/web/src/components/PlexTrack.tsx
@@ -12,7 +12,6 @@ type Props = {
         artists: string[];
         title: string;
         reason?: string;
-        album?: string;
     }
     readonly data?: SearchResponse
     readonly songIdx: number
@@ -203,7 +202,6 @@ export default function PlexTrack(props: Props) {
                     <ManualSearchPopup
                         trackTitle={trackTitle}
                         artistNames={artistNames}
-                        albumName={track.album}
                         onClose={onCloseManualSearch}
                         onSelect={onManualSelectTrack}
                     />

--- a/apps/web/src/components/PlexTrack.tsx
+++ b/apps/web/src/components/PlexTrack.tsx
@@ -114,6 +114,9 @@ export default function PlexTrack(props: Props) {
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                 {!!loading && <CircularProgress size={20} />}
                 {!loading && <>
+                    <Tooltip title="Manual match">
+                        <IconButton size="small" color="warning" onClick={onShowManualSearchClick}><Edit sx={{ fontSize: '1em' }} /></IconButton>
+                    </Tooltip>
                     {!!data && data.result.length > 0 &&
                         <>
                             {!!data && data.result.length > 1 &&
@@ -128,9 +131,6 @@ export default function PlexTrack(props: Props) {
                     }
                     {!!data && data.result.length === 0 &&
                         <>
-                            <Tooltip title="Manual match">
-                                <IconButton size="small" color="warning" onClick={onShowManualSearchClick}><Edit sx={{ fontSize: '1em' }} /></IconButton>
-                            </Tooltip>
                             <Tooltip title="Song not found">
                                 <IconButton size="small" color="warning" onClick={onNotPerfectMatchClick}><Warning sx={{ fontSize: '1em' }} /></IconButton>
                             </Tooltip>

--- a/packages/plex-music-search/src/actions/hubSearch.ts
+++ b/packages/plex-music-search/src/actions/hubSearch.ts
@@ -11,7 +11,7 @@ export default function hubSearch(uri: string, token: string, query: string, lim
     return new Promise<HubSearchResult[]>((resolve, reject) => {
 
         // Fix forbidden characters
-        const forbiddenCharacters = [ '/', "...", "..", '"']
+        const forbiddenCharacters = ["...", "..", '"']
 
         for (let i = 0; i < forbiddenCharacters.length; i++) {
             const element = forbiddenCharacters[i];

--- a/packages/shared-utils/src/spotify/extractTrackId.ts
+++ b/packages/shared-utils/src/spotify/extractTrackId.ts
@@ -32,7 +32,7 @@ export function isLocalTrack(trackId: string | undefined | null): boolean {
  * Format: spotify:local:artist:album:track:duration
  */
 export function extractLocalTrackArtist(trackId: string | undefined | null): string | null {
-    if (!isLocalTrack(trackId)) return null;
+    if (!trackId || !trackId.startsWith('spotify:local:')) return null;
 
     const parts = trackId.split(':');
     // parts[0] = 'spotify', parts[1] = 'local', parts[2] = artist
@@ -47,7 +47,7 @@ export function extractLocalTrackArtist(trackId: string | undefined | null): str
  * Format: spotify:local:artist:album:track:duration
  */
 export function extractLocalTrackAlbum(trackId: string | undefined | null): string | null {
-    if (!isLocalTrack(trackId)) return null;
+    if (!trackId || !trackId.startsWith('spotify:local:')) return null;
 
     const parts = trackId.split(':');
     // parts[0] = 'spotify', parts[1] = 'local', parts[2] = artist, parts[3] = album
@@ -62,7 +62,7 @@ export function extractLocalTrackAlbum(trackId: string | undefined | null): stri
  * Format: spotify:local:artist:album:track:duration
  */
 export function extractLocalTrackTitle(trackId: string | undefined | null): string | null {
-    if (!isLocalTrack(trackId)) return null;
+    if (!trackId || !trackId.startsWith('spotify:local:')) return null;
 
     const parts = trackId.split(':');
     // parts[0] = 'spotify', parts[1] = 'local', parts[2] = artist, parts[3] = album, parts[4] = track

--- a/packages/shared-utils/src/spotify/extractTrackId.ts
+++ b/packages/shared-utils/src/spotify/extractTrackId.ts
@@ -36,7 +36,7 @@ export function extractLocalTrackArtist(trackId: string | undefined | null): str
 
     const parts = trackId.split(':');
     // parts[0] = 'spotify', parts[1] = 'local', parts[2] = artist
-    if (parts.length >= 3) {
+    if (parts.length >= 3 && parts[2]) {
         return decodeURIComponent(parts[2]);
     }
     return null;
@@ -51,7 +51,7 @@ export function extractLocalTrackAlbum(trackId: string | undefined | null): stri
 
     const parts = trackId.split(':');
     // parts[0] = 'spotify', parts[1] = 'local', parts[2] = artist, parts[3] = album
-    if (parts.length >= 4) {
+    if (parts.length >= 4 && parts[3]) {
         return decodeURIComponent(parts[3]);
     }
     return null;
@@ -66,7 +66,7 @@ export function extractLocalTrackTitle(trackId: string | undefined | null): stri
 
     const parts = trackId.split(':');
     // parts[0] = 'spotify', parts[1] = 'local', parts[2] = artist, parts[3] = album, parts[4] = track
-    if (parts.length >= 5) {
+    if (parts.length >= 5 && parts[4]) {
         return decodeURIComponent(parts[4]);
     }
     return null;

--- a/packages/shared-utils/src/spotify/extractTrackId.ts
+++ b/packages/shared-utils/src/spotify/extractTrackId.ts
@@ -31,7 +31,7 @@ export function isLocalTrack(trackId: string | undefined | null): boolean {
  * Extracts artist name from a local track URI
  * Format: spotify:local:artist:album:track:duration
  */
-export function extractLocalTrackArtist(trackId: string): string | null {
+export function extractLocalTrackArtist(trackId: string | undefined | null): string | null {
     if (!isLocalTrack(trackId)) return null;
 
     const parts = trackId.split(':');
@@ -46,7 +46,7 @@ export function extractLocalTrackArtist(trackId: string): string | null {
  * Extracts album name from a local track URI
  * Format: spotify:local:artist:album:track:duration
  */
-export function extractLocalTrackAlbum(trackId: string): string | null {
+export function extractLocalTrackAlbum(trackId: string | undefined | null): string | null {
     if (!isLocalTrack(trackId)) return null;
 
     const parts = trackId.split(':');
@@ -61,7 +61,7 @@ export function extractLocalTrackAlbum(trackId: string): string | null {
  * Extracts track title from a local track URI
  * Format: spotify:local:artist:album:track:duration
  */
-export function extractLocalTrackTitle(trackId: string): string | null {
+export function extractLocalTrackTitle(trackId: string | undefined | null): string | null {
     if (!isLocalTrack(trackId)) return null;
 
     const parts = trackId.split(':');

--- a/packages/shared-utils/src/spotify/extractTrackId.ts
+++ b/packages/shared-utils/src/spotify/extractTrackId.ts
@@ -1,0 +1,73 @@
+/**
+ * Extracts a unique identifier for a Spotify track from its URI or ID
+ * Handles both regular tracks (spotify:track:id) and local tracks (spotify:local:artist:album:title:duration)
+ */
+export function extractTrackId(trackId: string | undefined | null): string | null {
+    if (!trackId) return null;
+
+    // Handle spotify:track: URIs
+    if (trackId.startsWith('spotify:track:')) {
+        return trackId.replace('spotify:track:', '');
+    }
+
+    // Handle spotify:local: URIs - use the full URI as unique identifier
+    // These tracks have the format: spotify:local:artist:album:track:duration
+    if (trackId.startsWith('spotify:local:')) {
+        return trackId; // Use full URI as unique ID for local tracks
+    }
+
+    // If it's already just an ID (no prefix), return as-is
+    return trackId;
+}
+
+/**
+ * Checks if a track ID represents a local track
+ */
+export function isLocalTrack(trackId: string | undefined | null): boolean {
+    return typeof trackId === 'string' && trackId.startsWith('spotify:local:');
+}
+
+/**
+ * Extracts artist name from a local track URI
+ * Format: spotify:local:artist:album:track:duration
+ */
+export function extractLocalTrackArtist(trackId: string): string | null {
+    if (!isLocalTrack(trackId)) return null;
+
+    const parts = trackId.split(':');
+    // parts[0] = 'spotify', parts[1] = 'local', parts[2] = artist
+    if (parts.length >= 3) {
+        return decodeURIComponent(parts[2]);
+    }
+    return null;
+}
+
+/**
+ * Extracts album name from a local track URI
+ * Format: spotify:local:artist:album:track:duration
+ */
+export function extractLocalTrackAlbum(trackId: string): string | null {
+    if (!isLocalTrack(trackId)) return null;
+
+    const parts = trackId.split(':');
+    // parts[0] = 'spotify', parts[1] = 'local', parts[2] = artist, parts[3] = album
+    if (parts.length >= 4) {
+        return decodeURIComponent(parts[3]);
+    }
+    return null;
+}
+
+/**
+ * Extracts track title from a local track URI
+ * Format: spotify:local:artist:album:track:duration
+ */
+export function extractLocalTrackTitle(trackId: string): string | null {
+    if (!isLocalTrack(trackId)) return null;
+
+    const parts = trackId.split(':');
+    // parts[0] = 'spotify', parts[1] = 'local', parts[2] = artist, parts[3] = album, parts[4] = track
+    if (parts.length >= 5) {
+        return decodeURIComponent(parts[4]);
+    }
+    return null;
+}

--- a/packages/shared-utils/src/spotify/getSpotifyPlaylist.ts
+++ b/packages/shared-utils/src/spotify/getSpotifyPlaylist.ts
@@ -22,15 +22,19 @@ export async function getSpotifyPlaylist(api: SpotifyApi, id: string, simplified
                 if (!item.track)
                     return null;
 
-                // Local files and unavailable tracks have null IDs - log for visibility
+                // Local files and unavailable tracks have null IDs - use URI instead
                 if (!item.track.id) {
                     console.log(`⚠️  Track without Spotify ID (local file or unavailable): "${item.track.name}" by ${item.track.artists?.[0]?.name || 'Unknown'}`);
+                    // Use URI as fallback for local/unavailable tracks
+                    if (!item.track.uri) {
+                        return null; // Skip if we have neither ID nor URI
+                    }
                 }
 
                 const artists = item.track.artists?.flatMap(artist => artist.name.split(',').map(name => name.trim()));
 
                 return {
-                    id: item.track.id,
+                    id: item.track.id || item.track.uri, // Use URI as fallback
                     title: item.track.name,
                     artist: item.track.artists?.[0]?.name || 'Unknown',
                     album: item.track.album?.name || 'Unknown',
@@ -69,13 +73,17 @@ export async function getSpotifyPlaylist(api: SpotifyApi, id: string, simplified
                 .map(item => {
                     if (!item.track) return null;
 
-                    // Local files and unavailable tracks have null IDs - log for visibility
+                    // Local files and unavailable tracks have null IDs - use URI instead
                     if (!item.track.id) {
                         console.log(`⚠️  Track without Spotify ID (local file or unavailable): "${item.track.name}" by ${item.track.artists?.[0]?.name || 'Unknown'}`);
+                        // Use URI as fallback for local/unavailable tracks
+                        if (!item.track.uri) {
+                            return null; // Skip if we have neither ID nor URI
+                        }
                     }
 
                     return {
-                        id: item.track.id,
+                        id: item.track.id || item.track.uri, // Use URI as fallback
                         title: item.track.name,
                         artist: item.track.artists?.[0]?.name || 'Unknown',
                         album: item.track.album?.name || 'Unknown',


### PR DESCRIPTION
Adds manual match support (works like "Fix Match" for metadata does in Plex) solving #104 

Also fixes local file tracks that you have uploaded to spotify as those have a different uri structure of `spotify:local:...`

Manually matched tracks & local files are still saved in `track_links.json` so they're cached for subsequent runs

I'll be honest pretty much all this code is copilot's doing. It does work reliably though may not meet some quality requirements, regardless I thought I might as well leave a PR open. Some screenshots are included below of the interface changes.

## Song list changes
<img width="1060" height="478" alt="image" src="https://github.com/user-attachments/assets/086e830e-3881-43ca-82af-655875ed0ebe" />

## Fix match popup
<img width="621" height="658" alt="image" src="https://github.com/user-attachments/assets/f8f2ac98-4b86-4cec-84e1-9dfdf0674019" />
