### PR TITLE
fix: handle new Spotify playlist response shape (tracks→items)

### DIFF
--- a/packages/shared-utils/src/spotify/getSpotifyPlaylist.ts
+++ b/packages/shared-utils/src/spotify/getSpotifyPlaylist.ts
@@ -17,26 +17,39 @@ export async function getSpotifyPlaylist(api: SpotifyApi, id: string, simplified
             tracks: []
         }
 
-        const validTracks = result.tracks.items
+        // Spotify Web API change (rolled out late 2024): user-authenticated
+        // /playlists/{id} responses now return the tracks page under `items`
+        // instead of `tracks`, and each entry exposes the track object as
+        // `item` instead of `track`. Read both shapes so the function keeps
+        // working for any account or region still on the legacy response.
+        const tracksPage = ((result as any).items ?? (result as any).tracks) as Page<PlaylistedTrack<Track>> | undefined;
+        if (!tracksPage?.items) {
+            console.error(`❌ Playlist ${id} response missing tracks page. Most likely fetched with client_credentials — Spotify no longer returns playlist tracks to that auth mode. A user access token is required.`);
+
+            return null;
+        }
+
+        const validTracks = tracksPage.items
             .map(item => {
-                if (!item.track)
+                const track: Track | undefined = (item as any).item ?? (item as any).track;
+                if (!track || typeof track !== 'object')
                     return null;
 
                 // Local files and unavailable tracks have null IDs - log for visibility
-                if (!item.track.id) {
-                    console.log(`⚠️  Track without Spotify ID (local file or unavailable): "${item.track.name}" by ${item.track.artists?.[0]?.name || 'Unknown'}`);
+                if (!track.id) {
+                    console.log(`⚠️  Track without Spotify ID (local file or unavailable): "${track.name}" by ${track.artists?.[0]?.name || 'Unknown'}`);
                 }
 
-                const artists = item.track.artists?.flatMap(artist => artist.name.split(',').map(name => name.trim()));
+                const artists = track.artists?.flatMap(artist => artist.name.split(',').map(name => name.trim()));
 
                 return {
-                    id: item.track.id,
-                    title: item.track.name,
-                    artist: item.track.artists?.[0]?.name || 'Unknown',
-                    album: item.track.album?.name || 'Unknown',
+                    id: track.id,
+                    title: track.name,
+                    artist: track.artists?.[0]?.name || 'Unknown',
+                    album: track.album?.name || 'Unknown',
                     artists: artists || [],
-                    album_id: item.track.album?.id || 'unknown',
-                    duration_ms: item.track.duration_ms
+                    album_id: track.album?.id || 'unknown',
+                    duration_ms: track.duration_ms
                 }
             })
             .filter((track) => !!track);
@@ -45,7 +58,7 @@ export async function getSpotifyPlaylist(api: SpotifyApi, id: string, simplified
         if (simplified)
             return playlist;
 
-        let nextUrl: string | null = result.tracks.next
+        let nextUrl: string | null = tracksPage.next
         while (nextUrl) {
 
             const response = await fetch(nextUrl, {
@@ -68,21 +81,22 @@ export async function getSpotifyPlaylist(api: SpotifyApi, id: string, simplified
 
             const validLoadMoreTracks = loadMore.items
                 .map(item => {
-                    if (!item.track) return null;
+                    const track: Track | undefined = (item as any).item ?? (item as any).track;
+                    if (!track || typeof track !== 'object') return null;
 
                     // Local files and unavailable tracks have null IDs - log for visibility
-                    if (!item.track.id) {
-                        console.log(`⚠️  Track without Spotify ID (local file or unavailable): "${item.track.name}" by ${item.track.artists?.[0]?.name || 'Unknown'}`);
+                    if (!track.id) {
+                        console.log(`⚠️  Track without Spotify ID (local file or unavailable): "${track.name}" by ${track.artists?.[0]?.name || 'Unknown'}`);
                     }
 
                     return {
-                        id: item.track.id,
-                        title: item.track.name,
-                        artist: item.track.artists?.[0]?.name || 'Unknown',
-                        album: item.track.album?.name || 'Unknown',
-                        artists: item.track.artists?.map(artist => artist.name) || [],
-                        album_id: item.track.album?.id || 'unknown',
-                        duration_ms: item.track.duration_ms
+                        id: track.id,
+                        title: track.name,
+                        artist: track.artists?.[0]?.name || 'Unknown',
+                        album: track.album?.name || 'Unknown',
+                        artists: track.artists?.map(artist => artist.name) || [],
+                        album_id: track.album?.id || 'unknown',
+                        duration_ms: track.duration_ms
                     }
                 })
                 .filter((track) => !!track);


### PR DESCRIPTION
## Problem

After Spotify's late-2024 Web API changes, `getSpotifyPlaylist()` returns `null` for every playlist when called with a connected user's access token, because it reads from a field name that no longer exists in the response.

That causes:

- **UI** — The "Send to Lidarr" button never appears (issue #118), because every track has `album: ""` / `album_id: "unknown"` after the scraper fallback fires.
- **Bulk Lidarr sync worker** — `POST /api/sync/lidarr` returns `{"ok":true}` and then hangs in `"running"` status forever. `lidarr_sync_log.json` stops receiving entries. Every album gets skipped by the existing `if (album.spotify_album_id === 'unknown')` guard in [`apps/sync-worker/src/jobs/lidarr.ts`](https://github.com/jjdenhertog/spotify-to-plex/blob/main/apps/sync-worker/src/jobs/lidarr.ts#L116).

Affects v1.0.104 (latest). Diagnostic notes I posted earlier: https://github.com/jjdenhertog/spotify-to-plex/issues/118#issuecomment-4528650618

## Root cause

The `/v1/playlists/{id}` response shape changed for user-authenticated requests. The data is still all there, but under new names:

| Before (legacy) | After (current) |
|---|---|
| `result.tracks` (Page object) | `result.items` |
| `result.tracks.items[].track` | `result.items.items[].item` |
| `result.tracks.next` → `/playlists/{id}/tracks?offset=…` | `result.items.next` → `/playlists/{id}/items?offset=…` |

The `@spotify/web-api-ts-sdk` types still declare the legacy shape, so the SDK passes the raw JSON through unchanged. [`packages/shared-utils/src/spotify/getSpotifyPlaylist.ts:20`](https://github.com/jjdenhertog/spotify-to-plex/blob/main/packages/shared-utils/src/spotify/getSpotifyPlaylist.ts#L20) then does `result.tracks.items.map(...)` → `TypeError: Cannot read properties of undefined (reading 'items')` → caught at line 100 → returns `null` → falls through to the scraper in `getSpotifyData`, which sets `album_id: 'unknown'`.

I verified the new shape directly against the live Spotify API with both a user token and `client_credentials`:

| Endpoint | User token | `client_credentials` |
|---|---|---|
| `GET /v1/playlists/{id}` | **200** — tracks under `items`, per-entry under `item` | 200 — but no `tracks` *or* `items` field at all |
| `GET /v1/playlists/{id}/tracks` | **403** | 403 |
| `GET /v1/playlists/{id}/items` | 200 — same new shape | not tested (auth-restricted) |

So a user token is now required to read playlist tracks at all, and the response shape is the new one.

## Fix

Two property accesses in `getSpotifyPlaylist.ts`, with a fallback to the legacy shape for any account/region still on the old response:

```ts
const tracksPage = ((result as any).items ?? (result as any).tracks) as Page<PlaylistedTrack<Track>> | undefined;
// ...
const track: Track | undefined = (item as any).item ?? (item as any).track;
```

If `tracksPage` is missing entirely (the `client_credentials` case), the function returns `null` with a clearer diagnostic so the symptom is easier to identify next time. `result.tracks.next` becomes `tracksPage.next`, which on the new shape already points at the working `/items` pagination URL — no further endpoint changes needed.

The `as any` casts are needed because the SDK's `Playlist` and `PlaylistedTrack` type declarations still describe the legacy shape; bumping the SDK is out of scope for this fix.

## Verification

Tested in the running container against the real Spotify API:

| Test | Result |
|---|---|
| 189-track user playlist, `simplified=false` (forces pagination across 2 pages) | **189/189 tracks** with real `album_id` (e.g. `4hVgANBVAWqCK6MoDTdZcv`). Pre-fix: 0/189. |
| Same playlist, `simplified=true` (first page only) | 100/100 tracks with real `album_id`. Pre-fix: 0/100. |
| Same playlist via `client_credentials` (no user connected) | Returns `null` gracefully with the new diagnostic message. Pre-fix: same `null`, less helpful error. |
| `api.albums.get(...)` shape | Unchanged — `result.tracks.items` still works for albums. The album path in `getSpotifyData` is left alone. |
| Editorial / Daily Mix playlist (`37i9dQZF1E38oGw5I4JObh`) | Still returns 404 to user tokens (this PR doesn't claim to fix that — falls through to the scraper, same as before). |

## Scope / non-goals

- Doesn't address Spotify's separate restriction on editorial playlists (404 to all auth modes). That falls through to the existing scraper path unchanged.
- Doesn't touch the `client_credentials` fallback in `loadSpotifyData.ts`. With this fix, user-token callers don't trip the fallback, and callers without a user token were already broken upstream of this code by Spotify's restrictions.
- Doesn't bump the `@spotify/web-api-ts-sdk` version. The SDK's types describe the legacy shape; runtime works fine because the SDK passes the raw response through.

Closes #118