### PR TITLE
Support duration as a match filter field

### DIFF
--- a/apps/web/src/components/popups/FieldSelectorPopup.tsx
+++ b/apps/web/src/components/popups/FieldSelectorPopup.tsx
@@ -22,7 +22,8 @@ const FieldSelectorPopup: React.FC<FieldSelectorPopupProps> = ({
         { value: 'title', label: 'Title', description: 'Match by track title' },
         { value: 'album', label: 'Album', description: 'Match by album name' },
         { value: 'artistWithTitle', label: 'Artist with Title', description: 'Match by artist and title combined' },
-        { value: 'artistInTitle', label: 'Artist in Title', description: 'Match artist name within track title' }
+        { value: 'artistInTitle', label: 'Artist in Title', description: 'Match artist name within track title' },
+        { value: 'duration', label: 'Duration', description: 'Match by track length (similarity only)' }
     ];
 
     const createFieldClickHandler = useCallback((field: FieldType) => () => {

--- a/apps/web/src/types/MatchFilterTypes.ts
+++ b/apps/web/src/types/MatchFilterTypes.ts
@@ -5,7 +5,7 @@
 export type MatchFilterRule = string; // e.g., "artist:match AND title:match"
 
 // Expression parsing types
-export type FieldType = 'artist' | 'title' | 'album' | 'artistWithTitle' | 'artistInTitle';
+export type FieldType = 'artist' | 'title' | 'album' | 'artistWithTitle' | 'artistInTitle' | 'duration';
 export type OperationType = 'match' | 'contains' | 'similarity' | 'is' | 'not';
 export type OperationText = OperationType | `similarity>=${number}`;
 export type CombinatorType = 'AND' | 'OR';

--- a/apps/web/src/utils/expressionToPills.ts
+++ b/apps/web/src/utils/expressionToPills.ts
@@ -50,7 +50,7 @@ export function expressionToPills(expression: string): Pill[] {
                 });
             } else {
                 // Check if this is just a field name without operation
-                const fieldOnlyPattern = /^(artist|title|album|artistWithTitle|artistInTitle)$/;
+                const fieldOnlyPattern = /^(artist|title|album|artistWithTitle|artistInTitle|duration)$/;
                 const fieldMatch = fieldOnlyPattern.exec(token);
                 
                 if (fieldMatch) {
@@ -78,7 +78,7 @@ export function expressionToPills(expression: string): Pill[] {
 
 function parseCondition(conditionText: string): ParsedCondition | null {
     // Match pattern: field:operation or field:operation>=threshold
-    const conditionPattern = /^(artist|title|album|artistWithTitle|artistInTitle):(match|contains|similarity(?:>=\d*\.?\d+)?)$/;
+    const conditionPattern = /^(artist|title|album|artistWithTitle|artistInTitle|duration):(match|contains|similarity(?:>=\d*\.?\d+)?)$/;
     const match = conditionPattern.exec(conditionText);
     
     if (!match) {

--- a/packages/music-search/src/functions/parseExpression.ts
+++ b/packages/music-search/src/functions/parseExpression.ts
@@ -21,7 +21,7 @@ type ParsedExpression = {
 /**
  * Safely parse expression syntax into executable filter function
  * Expression format: "artist:match AND title:contains"
- * Supported fields: artist, title, album, artistWithTitle, artistInTitle
+ * Supported fields: artist, title, album, artistWithTitle, artistInTitle, duration
  * Supported operations: :match, :contains, :is, :not, :similarity>=threshold
  * Supported combinators: AND, OR
  */
@@ -94,7 +94,7 @@ function parseCondition(conditionStr: string): ParsedCondition {
     }
 
     // Validate field
-    const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle'];
+    const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle', 'duration'];
 
     if (!validFields.includes(field)) {
         throw new Error(`Invalid field: ${field}`);
@@ -217,6 +217,12 @@ function getMatchingField(item: Track, field: string) {
             return item.matching.artistWithTitle;
         case 'artistInTitle':
             return item.matching.artistInTitle;
+        case 'duration': {
+            // duration only supports :similarity — 0 when either side lacks a duration
+            const { duration } = item.matching;
+
+            return duration ? { match: false, contains: false, similarity: duration.similarity } : null;
+        }
         default:
             return null;
     }

--- a/packages/shared-utils/src/validation/validateExpression.ts
+++ b/packages/shared-utils/src/validation/validateExpression.ts
@@ -16,14 +16,15 @@ export function validateExpression(expression: string): ValidationResult {
         }
         
         // Validate field names - check both standalone fields and fields with operations
-        const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle'];
+        // Must stay in sync with parseExpression's validFields (music-search)
+        const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle', 'duration'];
         
         // Extract fields with operations
         const fieldWithOpRegex = /([A-Za-z]+):/g;
         const fieldsWithOps = Array.from(expression.matchAll(fieldWithOpRegex), m => m[1]);
         
         // Extract standalone fields (not followed by colon)
-        const standaloneFieldRegex = /\b(artist|title|album|artistWithTitle|artistInTitle)\b(?!:)/g;
+        const standaloneFieldRegex = /\b(artist|title|album|artistWithTitle|artistInTitle|duration)\b(?!:)/g;
         const standaloneFields = Array.from(expression.matchAll(standaloneFieldRegex), m => m[1]);
         
         // Combine and validate all fields


### PR DESCRIPTION
Implements #77.

`search()` already computes a duration similarity for every candidate (`1 - |a-b| / max(a,b)`), but it is only used as a half-weighted tie-breaker in the candidate sort. No match filter can veto on it, so a row like `artist:match AND title:match` happily accepts an 8:42 album cut for a 3:03 single — the case that sent me digging.

This exposes `duration` to the filter expression grammar so users can opt in per row:

```
artist:match AND title:match AND duration:similarity>=0.65
```

Changes:
- `parseExpression`: accepts `duration` as a field, mapped to `matching.duration`
- `validateExpression`: same field list, kept in sync
- match-filter editor UI: `duration` added to the field type, the selector popup and the pill parser

Notes:
- Only `:similarity>=` is meaningful for duration; `:match`/`:contains` evaluate false.
- When either side lacks a duration the similarity is 0, so duration-guarded rows fail closed and later rows still apply.

## This does nothing until the guard is in someone's filters

Worth being explicit, because it is the main open question on this PR: **`DEFAULT_MATCH_FILTERS` in `packages/music-search/src/config/default-config.ts` is deliberately untouched here.** As it stands this PR only makes the syntax available — an existing install keeps matching exactly as before, and a fresh install gets no benefit at all unless the user hand-edits their filters. Nobody gets the fix by default.

I left the defaults alone because it changes matching behaviour for every existing user and that felt like your call rather than something to fold into a capability PR. The set I have been running, if you want it as the default (guard on every row, `0.65`):

```
artist:match AND title:match AND duration:similarity>=0.65
artist:contains AND title:match AND duration:similarity>=0.65
artist:similarity>=0.85 AND title:similarity>=0.85 AND duration:similarity>=0.65
artist:match AND title:similarity>=0.8 AND duration:similarity>=0.65
artist:match AND title:contains AND duration:similarity>=0.65
artistWithTitle:similarity>=0.9 AND duration:similarity>=0.65
artist:contains AND title:contains AND album:contains AND duration:similarity>=0.65
artist:similarity>=0.7 AND album:match AND title:similarity>=0.85 AND duration:similarity>=0.65
```

Two things about that block:

**Threshold.** `0.65` keeps radio-vs-album variance (0.8–0.9) and kills version-level mismatches. Exact-length copies score 0.99+.

**Order.** That is also tiers 2 and 3 swapped relative to the current defaults — `artist:match AND title:contains` moved down below the exact-title rows. Filters evaluate in order and the first row returning anything wins, so ordering decides which *imperfect* match is preferred when nothing matches perfectly. Demoting the `title:contains` row means an exact title by a slightly-off artist beats an exact artist with a merely-contained title, which stopped bare "Exceeder" being preferred over "Perfect (Exceeder)" in my library. Independent of this PR and easy to drop if you disagree — the duration guard is the part that matters here.

**The honest caveat if you do change the defaults:** some tracks that currently match will become misses. That is the intent — they are wrong-version matches — and misses flow to the Lidarr/slskd/Tidal integrations and resolve themselves once the correct file lands, whereas a wrong match is silent and permanent. But it does mean playlists can briefly shrink on the first sync after upgrading, so it probably deserves a release note. On my library it was 12 slots out of ~1,000.

Also worth noting alongside #130: that PR applies the same duration check to *cached* links with a threshold in code, so it works regardless of a user's filters. Between the two, defaults-unchanged users still get the wrong-version self-heal on cached links; what they miss without the config is duration vetoing a fresh wrong match at accept time.

Running with the guard on every row against my library (~1,190 tracks per sync, largest playlist 463 tracks): the wrong-length mismatch class is gone, legitimate matches unaffected.
