### PR TITLE
Expand album search hits into their tracks after all queries

### DIFF
--- a/packages/plex-music-search/src/utils/searching/searchForTrack.ts
+++ b/packages/plex-music-search/src/utils/searching/searchForTrack.ts
@@ -7,18 +7,6 @@ export async function searchForTrack(uri: string, token: string, artist: string,
     // Search for artist + track
     const searchResult = await hubSearch(uri, token, search, 20);
 
-    const albums = searchResult.filter(item => item.type == "album");
-    const [foundAlbum] = albums;
-    if (searchResult.length == albums.length && foundAlbum) {
-        
-        const trackResult: HubSearchResult[] = await getAlbumTracks(uri, token, foundAlbum.id)
-        trackResult.forEach(item => {
-            if (searchResult.filter(existingItem => existingItem.guid == item.guid).length == 0)
-                searchResult.push(item);
-        });
-
-    }
-
     // Search for track name
     {
         const alternativeSearchResult = await hubSearch(uri, token, track, 50);
@@ -46,6 +34,22 @@ export async function searchForTrack(uri: string, token: string, artist: string,
             if (searchResult.filter(existingItem => existingItem.guid == item.guid).length == 0)
                 searchResult.push(item);
         });
+    }
+
+    // Expand album hits from ALL queries above into their tracks: Plex's track
+    // search index can miss tracks whose album IS indexed, and album hits often
+    // only surface on the title-only query
+    const albums = searchResult.filter(item => item.type == "album");
+    for (const album of albums.slice(0, 3)) {
+        try {
+            const trackResult: HubSearchResult[] = await getAlbumTracks(uri, token, album.id)
+            trackResult.forEach(item => {
+                if (searchResult.filter(existingItem => existingItem.guid == item.guid).length == 0)
+                    searchResult.push(item);
+            });
+        } catch (_e) {
+            // Ignore albums that fail to load
+        }
     }
 
     return searchResult;


### PR DESCRIPTION
Plex's track search index can miss tracks whose album IS indexed. Live example from my server: `/hubs/search?query=perfect exceeder` returns the album (10 tracks on disk) but not a single one of its tracks — the only track hits are copies of the same song on unrelated compilations. A track in that state can never be matched no matter how good the filters are, because it never becomes a candidate.

`searchForTrack()` already has an album→tracks expansion, but it only runs when the result set contains nothing but albums. One stray track hit suppresses it entirely — which is exactly what happens here, the compilation copy being the stray hit.

This runs the expansion whenever album hits are present (capped at 3 albums, failures ignored) and moves it after all the alternative queries: album hubs often only surface on the title-only query, so expanding after just the first query isn't enough. Found that out the hard way while testing.

Fixes the "I know this track is in my library but it won't match" class from #74 / #115 / #86: once the album is expanded, an exact title+artist candidate exists and the normal filters pick it.
