### PR TITLE
Drop cached track links whose duration contradicts the Spotify track

### DIFF
--- a/apps/sync-worker/src/utils/getCachedPlexTracks.ts
+++ b/apps/sync-worker/src/utils/getCachedPlexTracks.ts
@@ -6,6 +6,8 @@ import { SearchResponse } from "@spotify-to-plex/plex-music-search/types/SearchR
 import { getById } from "@spotify-to-plex/plex-music-search/functions/getById";
 import { PlexMusicSearchConfig } from "@spotify-to-plex/plex-music-search/types/PlexMusicSearchConfig";
 
+const DURATION_LINK_THRESHOLD = 0.65;
+
 export async function getCachedPlexTracks(plexSearchConfig: PlexMusicSearchConfig, data: GetSpotifyPlaylist | GetSpotifyAlbum) {
     const { add, found: cachedTrackLinks } = getCachedTrackLinks(data.tracks, 'plex');
     const result: SearchResponse[] = [];
@@ -31,8 +33,21 @@ export async function getCachedPlexTracks(plexSearchConfig: PlexMusicSearchConfi
             try {
                 const metaData = await getById(plexSearchConfig, plexId);
 
-                if (metaData)
-                    foundTracks.push(metaData);
+                if (!metaData)
+                    continue;
+
+                // Drop links whose duration is far off the Spotify track — a wrong-version
+                // match cached before the right album existed (mirrors search()'s formula)
+                if (searchItem.duration_ms && metaData.duration_ms) {
+                    const similarity = 1 - Math.abs(searchItem.duration_ms - metaData.duration_ms) / Math.max(searchItem.duration_ms, metaData.duration_ms);
+
+                    if (similarity < DURATION_LINK_THRESHOLD) {
+                        console.log(`Dropping cached link for "${searchItem.title}": duration mismatch (${Math.round(similarity * 100)}%)`);
+                        continue;
+                    }
+                }
+
+                foundTracks.push(metaData);
             } catch (_e) {
             }
         }

--- a/apps/sync-worker/src/utils/getCachedPlexTracks.ts
+++ b/apps/sync-worker/src/utils/getCachedPlexTracks.ts
@@ -25,6 +25,11 @@ export async function getCachedPlexTracks(plexSearchConfig: PlexMusicSearchConfi
         // Load the plex tracks data
         const foundTracks: PlexTrack[] = [];
 
+        // Ids worth keeping in the cache. A rejected link is dropped so it is not
+        // re-fetched and re-logged on every sync; a lookup that *failed* is kept,
+        // because Plex being briefly unreachable is not evidence the link is wrong
+        const keptIds: string[] = [];
+
         for (let j = 0; j < trackLink.plex_id.length; j++) {
             const plexId = trackLink.plex_id[j];
             if (!plexId)
@@ -33,12 +38,15 @@ export async function getCachedPlexTracks(plexSearchConfig: PlexMusicSearchConfi
             try {
                 const metaData = await getById(plexSearchConfig, plexId);
 
-                if (!metaData)
+                if (!metaData) {
+                    keptIds.push(plexId);
                     continue;
+                }
 
                 // Drop links whose duration is far off the Spotify track — a wrong-version
                 // match cached before the right album existed (mirrors search()'s formula)
-                if (searchItem.duration_ms && metaData.duration_ms) {
+                // Manual picks are exempt: someone chose that version on purpose
+                if (!trackLink.manual && searchItem.duration_ms && metaData.duration_ms) {
                     const similarity = 1 - Math.abs(searchItem.duration_ms - metaData.duration_ms) / Math.max(searchItem.duration_ms, metaData.duration_ms);
 
                     if (similarity < DURATION_LINK_THRESHOLD) {
@@ -47,10 +55,16 @@ export async function getCachedPlexTracks(plexSearchConfig: PlexMusicSearchConfi
                     }
                 }
 
+                keptIds.push(plexId);
                 foundTracks.push(metaData);
             } catch (_e) {
+                keptIds.push(plexId);
             }
         }
+
+        // Persisted by the add() call that follows the re-search these drops trigger
+        if (keptIds.length !== trackLink.plex_id.length)
+            trackLink.plex_id = keptIds;
 
         // Try searching again if no tracks are found
         if (foundTracks.length == 0)

--- a/packages/plex-music-search/src/functions/getById.ts
+++ b/packages/plex-music-search/src/functions/getById.ts
@@ -22,6 +22,7 @@ export async function getById(config: PlexMusicSearchConfig, key: string) {
         guid: item.guid || '',
         image: item.thumb || '',
         title: item.title || '',
+        duration_ms: item.duration,
         src,
         album: {
             guid: item.parentGuid || '',

--- a/packages/shared-types/src/common/track.ts
+++ b/packages/shared-types/src/common/track.ts
@@ -1,5 +1,7 @@
 export type TrackLink = {
     spotify_id: string
+    /** Chosen by a person, so heuristics must not silently discard it */
+    manual?: boolean
     plex_id?: string[]
     tidal_id?: string[]
     slskd_files?: {

--- a/packages/shared-utils/src/cache/getCachedTrackLink.ts
+++ b/packages/shared-utils/src/cache/getCachedTrackLink.ts
@@ -83,6 +83,9 @@ export function getCachedTrackLinks(
                     case "plex":
                         trackLink.plex_id = item.result
                             .map(item => item.id)
+                        // Overwritten by an automatic search, so no longer a manual pick
+                        if (trackLink.manual)
+                            delete trackLink.manual
                         break;
 
                     case "tidal":


### PR DESCRIPTION
Fixes #127.

`track_links.json` entries are reused forever. A wrong match cached once — in my case Faithless' 8:42 "Insomnia" cached for a 3:03 orchestral cover, before the right album was in the library — stays in every playlist for good. Downloading the correct album changes nothing, because cached tracks are never re-searched. Missing tracks self-heal; wrong matches never do.

This makes duration-contradicted links heal the same way:

- `getById()` now returns the Plex track duration
- `getCachedPlexTracks()` drops a cached `plex_id` whose duration similarity vs the Spotify track is below 0.65, with a log line. If no id survives, the track falls through to the existing re-search path.

The threshold only fires on version-level mismatches: 0.65 keeps radio-vs-album variance and kills radio-vs-extended and wrong-recording links. A track whose only copy is the wrong version becomes missing instead — and is relinked automatically once the right one arrives through the download flow.

First sync against my library dropped 85 stale links; most re-matched to correct copies in the same run and playlist contents settled immediately. Pairs well with duration-guarded match filters (#77) so the re-search can't simply re-accept the same wrong candidate.


---

**Two follow-ups from running this for a few days, both pushed to the branch.**

**A rejected link has to be pruned, or it is re-evaluated forever.** Leaving the id in
`track_links.json` meant every sync re-fetched it, re-ran the duration check and logged the same
rejection again — my "Dropping cached link" count sat at 69 night after night and never fell,
however many correct files arrived. The id is now removed from the entry, which persists via the
`add()` that follows the re-search the drop triggers. Two consecutive syncs went 65 then 0.

Ids whose *lookup* failed are deliberately kept. Plex being briefly unreachable is not evidence
that a link is wrong, and pruning on a transient error would quietly delete good links.

**A manual match must outrank this heuristic.** With #134 (manual match) also in play, a person
deliberately choosing a version more than 35% off the Spotify duration — an extended mix, say —
had that choice silently dropped on the next sync and re-searched. `TrackLink` now records a
manual pick, this guard skips those links, and an automatic re-search clears the flag since the
link is no longer a manual choice. Verified both ways on the same link at 35% similarity: with
the flag it is kept, without it it is dropped.

Worth knowing if #134 is merged first — the two changes collide otherwise.
