### PR TITLE
Fall back to single-track lookups when batch enrichment is forbidden

### DIFF
--- a/packages/shared-utils/src/spotify/getSpotifyData.ts
+++ b/packages/shared-utils/src/spotify/getSpotifyData.ts
@@ -206,9 +206,12 @@ export async function getSpotifyData(api: SpotifyApi, id: string, simplified: bo
                     console.log(`Rate limited. Waiting ${backoffDelay}ms before retry ${retryCount}/${MAX_RETRIES}...`);
                     await new Promise(resolve => { setTimeout(resolve, backoffDelay) });
                 } else {
-                    // For other errors, just log and continue with original track data
-                    console.error(`Error enriching batch - ${retryCount}/${MAX_RETRIES}: ${batchError.message}`);
-                    success = true; // Don't retry non-rate-limit errors
+                    // Batch /v1/tracks?ids= is 403-forbidden for restricted-mode tokens
+                    // while single-track lookups still work - enrich one by one instead
+                    console.error(`Error enriching batch - ${retryCount}/${MAX_RETRIES}: ${batchError.message}. Falling back to single-track lookups.`);
+                    const enrichedBatch = await enrichTracksIndividually(api, batch, BATCH_DELAY);
+                    tracks.splice(i, BATCH_SIZE, ...enrichedBatch);
+                    success = true;
                 }
             }
         }
@@ -236,4 +239,37 @@ export async function getSpotifyData(api: SpotifyApi, id: string, simplified: bo
 
     return null
 
+}
+
+type EnrichableTrack = {
+    id: string;
+    album: string;
+    album_id: string;
+    duration_ms?: number;
+};
+
+async function enrichTracksIndividually<T extends EnrichableTrack>(api: SpotifyApi, batch: T[], delayMs: number): Promise<T[]> {
+    const result = [...batch];
+
+    for (let i = 0; i < result.length; i++) {
+        const track = result[i];
+        if (!track?.id || track.id.startsWith('spotify:local:'))
+            continue;
+
+        try {
+            const enrichedTrack = await api.tracks.get(track.id.replace('spotify:track:', ''));
+            result[i] = {
+                ...track,
+                album: enrichedTrack.album.name,
+                album_id: enrichedTrack.album.id,
+                duration_ms: track.duration_ms ?? enrichedTrack.duration_ms
+            };
+        } catch (_e) {
+            // Keep the scraper data for tracks that fail individually
+        }
+
+        await new Promise(resolve => { setTimeout(resolve, delayMs) });
+    }
+
+    return result;
 }


### PR DESCRIPTION
For development-mode (restricted) Spotify apps the batch endpoint `/v1/tracks?ids=` returns 403 while the single `/v1/tracks/{id}` endpoint works, verified against the live API with the same client-credentials token:

```
single /v1/tracks/{id}: 200
batch  /v1/tracks?ids=: 403 {"error": {"status": 403, "message": "Forbidden"}}
```

`getSpotifyData()`'s enrichment loop only uses the batch call and, on a non-rate-limit failure, keeps the raw scraper data. Scraper tracks then keep `album_id: 'unknown'` — and the Lidarr sync skips those tracks entirely. Net effect: for scraper-sourced playlists (all the Spotify-personalized ones), missing tracks silently never reach Lidarr.

This adds a per-track fallback when the batch call fails with a non-429 error, at the same request pacing as the batch path. Local-file URIs are skipped and individual failures keep the scraper data.

After deploying: the "Skipping track with unknown album_id" lines went from 7 to 0 and the personalized playlists' missing albums reached the Lidarr queue for the first time.
