### PR TITLE
Raise API body limit for large playlists

### DIFF
--- a/apps/web/pages/api/playlists/[id].ts
+++ b/apps/web/pages/api/playlists/[id].ts
@@ -17,6 +17,16 @@ export type GetPlexPlaylistIdResponse = {
     id: string,
     link: string
 }
+// Large playlists ship thousands of tracks in one request/response (issue #94)
+export const config = {
+    api: {
+        bodyParser: {
+            sizeLimit: '8mb',
+        },
+        responseLimit: false,
+    },
+}
+
 const router = createRouter<NextApiRequest, NextApiResponse>()
     .get(
         async (req, res) => {

--- a/apps/web/pages/api/playlists/index.ts
+++ b/apps/web/pages/api/playlists/index.ts
@@ -18,6 +18,16 @@ export type GetPlexPlaylistResponse = {
     title: Playlist["title"],
 }
 
+// Large playlists ship thousands of tracks in one request/response (issue #94)
+export const config = {
+    api: {
+        bodyParser: {
+            sizeLimit: '8mb',
+        },
+        responseLimit: false,
+    },
+}
+
 const router = createRouter<NextApiRequest, NextApiResponse>()
     .get(
         async (_req, res, _next) => {

--- a/apps/web/pages/api/plex/cached.ts
+++ b/apps/web/pages/api/plex/cached.ts
@@ -26,6 +26,16 @@ async function getPlexTracks(plexIds: string[], plexConfig: any) {
 }
 
 
+// Large playlists ship thousands of tracks in one request/response (issue #94)
+export const config = {
+    api: {
+        bodyParser: {
+            sizeLimit: '8mb',
+        },
+        responseLimit: false,
+    },
+}
+
 const router = createRouter<NextApiRequest, NextApiResponse>()
     .post(
         async (req, res) => {

--- a/apps/web/pages/api/plex/tracks.ts
+++ b/apps/web/pages/api/plex/tracks.ts
@@ -10,6 +10,16 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { createRouter } from 'next-connect';
 import { getSettings } from '@spotify-to-plex/plex-config/functions/getSettings';
 
+// Large playlists ship thousands of tracks in one request/response (issue #94)
+export const config = {
+    api: {
+        bodyParser: {
+            sizeLimit: '8mb',
+        },
+        responseLimit: false,
+    },
+}
+
 const router = createRouter<NextApiRequest, NextApiResponse>()
     .post(
         async (req, res) => {


### PR DESCRIPTION
Fixes #94.

The playlist endpoints receive the full track list in one JSON body. Next.js' default `bodyParser` limit is 1MB, so multi-thousand-track playlists (Liked Songs being the usual case) die with HTTP 413 before the handler runs.

This raises the limit to 8MB on `/api/plex/tracks`, `/api/plex/cached` and `/api/playlists[/{id}]`, and lifts the response size warning on the search routes, which return a `SearchResponse` per track and pass 4MB well before the request body does.
