### PR TITLE
Match cache writes by Spotify id instead of title/artist equality

### DIFF
--- a/packages/shared-utils/src/cache/getCachedTrackLink.ts
+++ b/packages/shared-utils/src/cache/getCachedTrackLink.ts
@@ -61,14 +61,18 @@ export function getCachedTrackLinks(
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const add = (searchResult: { title: string, artist: string, result: any[] }[], type: "tidal" | "plex" | "slskd", album?: { id: string }) => {
+    const add = (searchResult: { id?: string, title: string, artist: string, result: any[] }[], type: "tidal" | "plex" | "slskd", album?: { id: string }) => {
 
         ////////////////////////////////
         // Cache tracks
         ////////////////////////////////
         searchResult.forEach(item => {
             if (item.result && item.result.length > 0) {
-                const searchItem = searchItems.find(toSearchItem => toSearchItem.title == item.title && toSearchItem.artists.indexOf(item.artist) > -1)
+                // Prefer the spotify id - title/artist equality misses multi-artist
+                // variants, leaving stale links that get re-searched every sync
+                const searchItem = searchItems.find(toSearchItem => item.id
+                    ? toSearchItem.id == item.id
+                    : (toSearchItem.title == item.title && toSearchItem.artists.indexOf(item.artist) > -1))
                 if (!searchItem)
                     return;
 


### PR DESCRIPTION
`getCachedTrackLinks()`' `add()` looks each search result back up by exact title equality plus artist membership. For multi-artist credits and title variants that lookup misses, so the cache write is silently skipped — and the track gets re-searched on every sync forever. Same results, no persistence, wasted Plex queries every night.

The search results already carry the Spotify id, so match on that. The old title/artist comparison stays as a fallback for callers that pass no id.
