### PR TITLE
Add version as a match filter field

### DIFF
--- a/apps/web/src/components/popups/FieldSelectorPopup.tsx
+++ b/apps/web/src/components/popups/FieldSelectorPopup.tsx
@@ -22,7 +22,8 @@ const FieldSelectorPopup: React.FC<FieldSelectorPopupProps> = ({
         { value: 'title', label: 'Title', description: 'Match by track title' },
         { value: 'album', label: 'Album', description: 'Match by album name' },
         { value: 'artistWithTitle', label: 'Artist with Title', description: 'Match by artist and title combined' },
-        { value: 'artistInTitle', label: 'Artist in Title', description: 'Match artist name within track title' }
+        { value: 'artistInTitle', label: 'Artist in Title', description: 'Match artist name within track title' },
+        { value: 'version', label: 'Version', description: 'Both titles name the same version (remix, edit, acoustic)' }
     ];
 
     const createFieldClickHandler = useCallback((field: FieldType) => () => {

--- a/apps/web/src/types/MatchFilterTypes.ts
+++ b/apps/web/src/types/MatchFilterTypes.ts
@@ -5,7 +5,7 @@
 export type MatchFilterRule = string; // e.g., "artist:match AND title:match"
 
 // Expression parsing types
-export type FieldType = 'artist' | 'title' | 'album' | 'artistWithTitle' | 'artistInTitle';
+export type FieldType = 'artist' | 'title' | 'album' | 'artistWithTitle' | 'artistInTitle' | 'version';
 export type OperationType = 'match' | 'contains' | 'similarity' | 'is' | 'not';
 export type OperationText = OperationType | `similarity>=${number}`;
 export type CombinatorType = 'AND' | 'OR';

--- a/apps/web/src/utils/expressionToPills.ts
+++ b/apps/web/src/utils/expressionToPills.ts
@@ -50,7 +50,7 @@ export function expressionToPills(expression: string): Pill[] {
                 });
             } else {
                 // Check if this is just a field name without operation
-                const fieldOnlyPattern = /^(artist|title|album|artistWithTitle|artistInTitle)$/;
+                const fieldOnlyPattern = /^(artist|title|album|artistWithTitle|artistInTitle|version)$/;
                 const fieldMatch = fieldOnlyPattern.exec(token);
                 
                 if (fieldMatch) {
@@ -78,7 +78,7 @@ export function expressionToPills(expression: string): Pill[] {
 
 function parseCondition(conditionText: string): ParsedCondition | null {
     // Match pattern: field:operation or field:operation>=threshold
-    const conditionPattern = /^(artist|title|album|artistWithTitle|artistInTitle):(match|contains|similarity(?:>=\d*\.?\d+)?)$/;
+    const conditionPattern = /^(artist|title|album|artistWithTitle|artistInTitle|version):(match|contains|similarity(?:>=\d*\.?\d+)?)$/;
     const match = conditionPattern.exec(conditionText);
     
     if (!match) {

--- a/packages/music-search/src/functions/parseExpression.ts
+++ b/packages/music-search/src/functions/parseExpression.ts
@@ -21,7 +21,7 @@ type ParsedExpression = {
 /**
  * Safely parse expression syntax into executable filter function
  * Expression format: "artist:match AND title:contains"
- * Supported fields: artist, title, album, artistWithTitle, artistInTitle
+ * Supported fields: artist, title, album, artistWithTitle, artistInTitle, version
  * Supported operations: :match, :contains, :is, :not, :similarity>=threshold
  * Supported combinators: AND, OR
  */
@@ -94,7 +94,7 @@ function parseCondition(conditionStr: string): ParsedCondition {
     }
 
     // Validate field
-    const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle'];
+    const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle', 'version'];
 
     if (!validFields.includes(field)) {
         throw new Error(`Invalid field: ${field}`);
@@ -217,6 +217,8 @@ function getMatchingField(item: Track, field: string) {
             return item.matching.artistWithTitle;
         case 'artistInTitle':
             return item.matching.artistInTitle;
+        case 'version':
+            return item.matching.version ?? null;
         default:
             return null;
     }

--- a/packages/music-search/src/functions/search.ts
+++ b/packages/music-search/src/functions/search.ts
@@ -1,6 +1,7 @@
 import { Track } from "../types/Track";
 import { compareTitles } from '@spotify-to-plex/shared-utils/music/compareTitles';
 import { removeFeaturing } from '@spotify-to-plex/shared-utils/music/removeFeaturing';
+import { compareVersions } from '../utils/compareVersions';
 import { getRuntimeFilters } from "./getRuntimeFilters";
 
 export function search(find: Track, options: Track[], analyze: boolean = false) {
@@ -23,6 +24,7 @@ export function search(find: Track, options: Track[], analyze: boolean = false) 
                 artistWithTitle: compareTitles(item.title, `${find.artist} ${find.title}`, true),
                 artist: compareTitles(item.artist, find.artist, true),
                 alternativeArtist: compareTitles(removeFeaturing(item.artist), find.artist, true),
+                version: compareVersions(item.title, find.title),
                 duration: { similarity: durationSimilarity, available: hasBothDurations },
             };
 

--- a/packages/music-search/src/types/Track.ts
+++ b/packages/music-search/src/types/Track.ts
@@ -12,6 +12,7 @@ export type Track = {
         artist: { match: boolean; contains: boolean; similarity: number; };
         artistInTitle: { match: boolean; contains: boolean; similarity: number; };
         artistWithTitle: { match: boolean; contains: boolean; similarity: number; };
+        version?: { match: boolean; contains: boolean; similarity: number; };
         duration?: { similarity: number; available: boolean; };
         isMatchingApproach?:boolean;
     };

--- a/packages/music-search/src/utils/compareVersions.ts
+++ b/packages/music-search/src/utils/compareVersions.ts
@@ -1,0 +1,66 @@
+import { getState } from "../functions/state/getState";
+
+// "(radio edit)", "[live]", "{dub}" and the trailing " - Radio Edit" form Spotify uses
+const BRACKETED = /\(([^)]*)\)|\[([^\]]*)]|\{([^}]*)}/g;
+const TRAILING_DASH = /\s-\s(.+)$/;
+
+// "(feat. X)", "(with X)", "(& X)" - a credit, not a version of the recording
+const CREDIT = /^(feat|feats|featuring|ft|with|w)\b|^[&+]/;
+// "From \"8 Mile\" Soundtrack" - provenance, not a version
+const PROVENANCE = /^from\b/;
+const YEAR = /\b(19|20)\d{2}\b/g;
+// Qualifiers that name no particular version
+// Longest first: "main mix" must be removed whole, or "main" leaves a bare "mix"
+const STRUCTURAL = ['album version', 'bonus track', 'main mix', 'radio mix', 'main', 'deluxe', 'explicit', 'clean', 'mono', 'stereo'];
+
+/**
+ * The version qualifier of a title - "acoustic", "jauz remix", "uk edit" - or ''
+ * when the title names no particular version. Credits, provenance and words the
+ * user treats as noise are not version distinctions.
+ */
+export function extractVersion(title: string, filterOutWords: string[]): string {
+    const segments: string[] = [];
+
+    for (const match of title.matchAll(BRACKETED))
+        segments.push(match[1] ?? match[2] ?? match[3] ?? '');
+
+    const trailing = TRAILING_DASH.exec(title.replace(BRACKETED, ''));
+    if (trailing?.[1])
+        segments.push(trailing[1]);
+
+    const meaningful = segments
+        .map(segment => segment.toLowerCase().trim())
+        .filter(segment => !CREDIT.test(segment) && !PROVENANCE.test(segment))
+        .map(segment => {
+            let result = segment;
+            for (const word of [...filterOutWords, ...STRUCTURAL])
+                result = result.split(word.toLowerCase()).join(' ');
+
+            return result.replace(YEAR, ' ').replace(/[^\d a-z]/g, '').replace(/\s+/g, ' ').trim();
+        })
+        // A qualifier reduced to a fragment carries no version meaning
+        .filter(segment => segment.length > 2);
+
+    return meaningful.join(' ');
+}
+
+/**
+ * Whether two titles name the same version. Duration cannot separate two
+ * different remixes of equal length, so this compares what the titles claim.
+ */
+export function compareVersions(a?: string, b?: string) {
+    if (!a || !b)
+        return { match: false, contains: false, similarity: 0 };
+
+    const filterOutWords = getState().musicSearchConfig?.textProcessing?.filterOutWords ?? [];
+    const versionA = extractVersion(a, filterOutWords);
+    const versionB = extractVersion(b, filterOutWords);
+
+    const match = versionA === versionB;
+
+    // One side naming a version the other does not is the mismatch worth
+    // catching: "Language" offered for "Language - UK Edit"
+    const contains = !!versionA && !!versionB && (versionA.includes(versionB) || versionB.includes(versionA));
+
+    return { match, contains, similarity: match ? 1 : 0 };
+}

--- a/packages/shared-utils/src/validation/validateExpression.ts
+++ b/packages/shared-utils/src/validation/validateExpression.ts
@@ -16,14 +16,14 @@ export function validateExpression(expression: string): ValidationResult {
         }
         
         // Validate field names - check both standalone fields and fields with operations
-        const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle'];
+        const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle', 'version'];
         
         // Extract fields with operations
         const fieldWithOpRegex = /([A-Za-z]+):/g;
         const fieldsWithOps = Array.from(expression.matchAll(fieldWithOpRegex), m => m[1]);
         
         // Extract standalone fields (not followed by colon)
-        const standaloneFieldRegex = /\b(artist|title|album|artistWithTitle|artistInTitle)\b(?!:)/g;
+        const standaloneFieldRegex = /\b(artist|title|album|artistWithTitle|artistInTitle|version)\b(?!:)/g;
         const standaloneFields = Array.from(expression.matchAll(standaloneFieldRegex), m => m[1]);
         
         // Combine and validate all fields


### PR DESCRIPTION
Duration cannot separate two different remixes of the same song, because they are usually the same length. That is not a hypothetical: a candidate matching at **99% on duration** put Tiësto's *In Search of Sunrise* remix edit of "Silence" into a playlist that asked for Fade's Sanctuary radio edit. Same song, same length, different recording. No duration threshold can see that, and neither can title similarity — the titles differ only in the part inside the brackets.

This adds `version` as a match filter field, comparing what the titles *claim*:

```
artist:match AND title:match AND version:match
```

`extractVersion` takes the qualifier from a title — bracketed segments and Spotify's trailing `" - Radio Edit"` form — and then discards everything that is not a version distinction:

- **featured-artist credits** — `(feat. X)`, `(ft. X)`, `(with X)`, `(& X)`. These are by far the most common parenthetical in music titles and they say nothing about the recording.
- **provenance** — `From "8 Mile" Soundtrack`
- **years** — so `- 2016 Remaster` reduces to nothing once `remaster` is removed
- **structural words** — `album version`, `main mix`, `bonus track`, `explicit`, `clean`
- **the user's own `filterOutWords`**, so `(Original Mix)` and `(Radio Edit)` stay noise rather than becoming differences

What survives is the part that actually names a version: `acoustic`, `jauz remix`, `uk edit`, `extended mix`.

### Measured, not assumed

I ran this against every linked track in my library (1080) and read the rejections rather than trusting the percentage.

A first cut rejected **21%** — and inspecting them showed the fault was entirely mine, not the idea: `Stereo Hearts (feat. Adam Levine)` vs `Stereo Hearts` is the same recording. Handling credits, provenance and years brought it to **8%**, and those remaining read as genuine mismatches:

```
Ride It                           ->  Ride It (Jonas Blue remix)
Pepas                             ->  Pepas (Tiësto remix)
Bad Memories - Felix Jaehn Remix  ->  Bad Memories
Titanium ... Future Rave Remix    ->  Titanium
Overdrive ... - Acoustic Version  ->  Overdrive
Take Over Control ... Radio Edit  ->  Take Over Control (Adam F. mix)
```

Plain tracks matched to remixes, remixes matched to plain tracks, and an acoustic matched to the studio cut.

### Notes

- Only `:match` is meaningful. A version either matches or it does not, so `:similarity` is 1 or 0.
- Defaults are untouched — nothing changes until a user adds `version` to a filter row.
- Enabling it does **not** retroactively fix existing wrong matches, because cached links never re-enter the search path. It prevents new ones; correcting old ones means clearing those cache entries so they are searched again.
- This touches the same field lists as #128 (`parseExpression`, `validateExpression`, and the three match-filter editor files). Whichever merges second needs a trivial rebase — there is no logical dependency between them.


### On the defaults

Same situation as #128, and worth stating plainly: **`DEFAULT_MATCH_FILTERS` is untouched here.** As it stands this PR only makes the field available — an existing install matches exactly as before, and a fresh install gets no benefit unless the user edits their filters. Nobody gets this by default.

I left defaults alone because it changes matching for everyone and that felt like your call. If you want it on, it appends to a row rather than replacing anything:

```
artist:match AND title:match AND version:match
```

**One clarification on the 8%, because it is easy to misread.** That number is *how many of my existing matches are wrong*, not how much would disappear on upgrade. Match filters only run in the search path, and cached links bypass search entirely — so enabling this changes nothing for links that already exist. Concretely: turning it on costs an existing user close to zero tracks immediately, and prevents new wrong matches from that point.

Correcting the existing ones is a separate, deliberate step: clear those cache entries so the tracks are searched again. I have now done both on my own library — `version:match` on all eight rows, and the 78 mismatched links cleared so they re-search. Happy to report back on what settles once it has run a few nights, if that is useful before you decide.
