### PR TITLE
Feature: Search a playlist, and review tracks that matched more than one candidate

### DIFF
--- a/apps/web/src/components/PlexPlaylist.tsx
+++ b/apps/web/src/components/PlexPlaylist.tsx
@@ -392,14 +392,7 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
         const songIdx = trackSelectIdx ? trackSelectIdx.idx : 0;
         const loading = loadingTracks && !(tracksLoaded.some(item => item === track.id))
 
-        return <PlexTrack
-            key={`${playlist.id}-plex-${track.title}-${track.id}}`}
-            loading={loading}
-            track={track}
-            setSongIdx={onSetSongIndex}
-            songIdx={songIdx}
-            data={data}
-        />
+        return <PlexTrack key={`${playlist.id}-plex-${track.title}-${track.id}}`} loading={loading} track={track} setSongIdx={onSetSongIndex} songIdx={songIdx} data={data} />
     }, [findMatchFor, trackSelections, loadingTracks, tracksLoaded, onSetSongIndex, playlist.id])
     const totalPages = Math.ceil(filteredTracks.length / pageSize)
     const visibleTracks = filteredTracks.slice(page * pageSize, (page * pageSize) + pageSize)

--- a/apps/web/src/components/PlexPlaylist.tsx
+++ b/apps/web/src/components/PlexPlaylist.tsx
@@ -333,7 +333,7 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
 
             return track.artists.indexOf(item.artist) > -1 && track.title === item.title
         })
-        , [tracks])
+    , [tracks])
 
     // Every track is already loaded client-side, so searching covers the whole
     // playlist rather than the current page
@@ -351,7 +351,7 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
             if (!search)
                 return true;
 
-            const haystack = [track.title, track.album, ...track.artists];
+            const haystack: (string | undefined)[] = [track.title, track.album, ...track.artists];
             if (data)
                 data.result.forEach(item => {
                     haystack.push(item.title, item.artist?.title, item.album?.title)

--- a/apps/web/src/components/PlexPlaylist.tsx
+++ b/apps/web/src/components/PlexPlaylist.tsx
@@ -5,9 +5,9 @@ import { GetSpotifyAlbum } from "@spotify-to-plex/shared-types/spotify/GetSpotif
 import { GetSpotifyPlaylist } from "@spotify-to-plex/shared-types/spotify/GetSpotifyPlaylist";
 import { Track } from "@spotify-to-plex/shared-types/spotify/Track";
 import type { SearchResponse } from "@spotify-to-plex/plex-music-search/types/SearchResponse";
-import { Edit, Refresh } from "@mui/icons-material";
+import { Edit, Refresh, Search } from "@mui/icons-material";
 import CloseIcon from '@mui/icons-material/Close';
-import { Alert, Box, Button, CircularProgress, Divider, IconButton, Input, Modal, Paper, Stack, Tooltip, Typography } from "@mui/material";
+import { Alert, Box, Button, CircularProgress, Divider, IconButton, Input, InputAdornment, Modal, Paper, Stack, TextField, Tooltip, Typography } from "@mui/material";
 import axios from "axios";
 import { enqueueSnackbar } from "notistack";
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -30,17 +30,33 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
     const { playlist, fast } = props
 
     ///////////////////////////////////////////////
-    // Pagination
+    // Searching & pagination
     ///////////////////////////////////////////////
     const pageSize = 30;
     const [page, setPage] = useState<number>(0);
     const [error, setError] = useState('')
-    const [totalPages, setTotalPages] = useState<number>(0);
+    const [query, setQuery] = useState<string>('')
+    const [onlyUnresolved, setOnlyUnresolved] = useState<boolean>(false)
     const prevPageClick = useCallback(() => {
         setPage(prev => prev - 1)
     }, [])
     const nextPageClick = useCallback(() => {
         setPage(prev => prev + 1)
+    }, [])
+
+    // Any filter change restarts at page 1, otherwise a narrow result set
+    // lands on a page that no longer exists
+    const onQueryChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+        setQuery(e.currentTarget.value)
+        setPage(0)
+    }, [])
+    const onClearQuery = useCallback(() => {
+        setQuery('')
+        setPage(0)
+    }, [])
+    const onToggleUnresolved = useCallback(() => {
+        setOnlyUnresolved(prev => !prev)
+        setPage(0)
     }, [])
 
     ///////////////////////////////////////////////
@@ -49,8 +65,6 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
     const [plexPlaylist, setPlexPlaylist] = useState<GetPlexPlaylistIdResponse>()
     useEffect(() => {
         if (!playlist) return;
-
-        setTotalPages(Math.ceil(playlist.tracks.length / pageSize))
 
         errorBoundary(async () => {
             const playlistResult = await axios.get<GetPlexPlaylistIdResponse>(`/api/playlists/${playlist.id}`)
@@ -309,10 +323,56 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
 
     }, [playlist, newPlaylistName, plexPlaylist, trackSelections, tracks])
 
-    const visibleTracks = playlist.tracks.slice(page * pageSize, (page * pageSize) + pageSize)
+    // Single owner for "which search result belongs to this track" - the filter
+    // and the row renderer must agree or the counts lie
+    const findMatchFor = useCallback((track: { title: string, artists: string[] }) =>
+        tracks.find(item => {
+            const mergedArtistsMatch = track.artists.join(',') == item.artist && track.title === item.title
+            if (mergedArtistsMatch)
+                return true;
+
+            return track.artists.indexOf(item.artist) > -1 && track.title === item.title
+        })
+        , [tracks])
+
+    // Every track is already loaded client-side, so searching covers the whole
+    // playlist rather than the current page
+    const filteredTracks = useMemo(() => {
+        const search = query.trim().toLowerCase();
+        if (!search && !onlyUnresolved)
+            return playlist.tracks;
+
+        return playlist.tracks.filter(track => {
+            const data = findMatchFor(track)
+
+            if (onlyUnresolved && !!data && data.result.length === 1)
+                return false;
+
+            if (!search)
+                return true;
+
+            const haystack = [track.title, track.album, ...track.artists];
+            if (data)
+                data.result.forEach(item => {
+                    haystack.push(item.title, item.artist?.title, item.album?.title)
+                });
+
+            return haystack.some(value => !!value && value.toLowerCase().includes(search));
+        })
+    }, [playlist.tracks, findMatchFor, query, onlyUnresolved])
+
+    const filtering = !!query.trim() || onlyUnresolved;
+    const totalPages = Math.ceil(filteredTracks.length / pageSize)
+    const visibleTracks = filteredTracks.slice(page * pageSize, (page * pageSize) + pageSize)
     let curEnd = (page * pageSize) + pageSize;
-    if (curEnd > playlist.tracks.length)
-        curEnd = playlist.tracks.length;
+    if (curEnd > filteredTracks.length)
+        curEnd = filteredTracks.length;
+
+    // Results can shrink under the current page while tracks are still resolving
+    useEffect(() => {
+        if (page > 0 && page >= totalPages)
+            setPage(Math.max(0, totalPages - 1))
+    }, [page, totalPages])
 
     //////////////////////////////////////////////
     // Handle missing tracks
@@ -461,6 +521,29 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
 
             <Divider sx={{ mt: 1, mb: 1 }} />
             <Stack>
+                <Box display="flex" gap={1} mb={1}>
+                    <TextField
+                        size="small"
+                        fullWidth
+                        placeholder="Search this playlist"
+                        value={query}
+                        onChange={onQueryChange}
+                        InputProps={{
+                            startAdornment: <InputAdornment position="start"><Search fontSize="small" /></InputAdornment>,
+                            endAdornment: !!query && <InputAdornment position="end">
+                                <IconButton size="small" onClick={onClearQuery} aria-label="Clear search"><CloseIcon fontSize="small" /></IconButton>
+                            </InputAdornment>
+                        }}
+                    />
+                    <Tooltip title="Show only tracks that are missing or have more than one candidate">
+                        <Button variant={onlyUnresolved ? 'contained' : 'outlined'} onClick={onToggleUnresolved} sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}>Needs review</Button>
+                    </Tooltip>
+                </Box>
+                {!!filtering &&
+                    <Typography variant="body2" sx={{ mb: 1, color: 'text.secondary' }}>
+                        {filteredTracks.length === 0 ? 'No tracks match' : `${filteredTracks.length} of ${playlist.tracks.length} tracks`}
+                    </Typography>
+                }
                 {totalPages > 1 &&
                     <Box display="flex" mb={1} justifyContent="space-between">
                         <Button variant="contained" disabled={page <= 0} onClick={prevPageClick}>Previous</Button>
@@ -469,15 +552,7 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
                     </Box>
                 }
                 {visibleTracks.map(track => {
-                    const data = tracks.find(item => {
-
-                        const mergedArtistsMatch = track.artists.join(',') == item.artist && track.title === item.title
-                        if (mergedArtistsMatch)
-                            return true;
-
-                        return track.artists.indexOf(item.artist) > -1 && track.title === item.title
-
-                    })
+                    const data = findMatchFor(track)
                     const trackSelectIdx = trackSelections.find(item => track.artists.indexOf(item.artist) > -1 && item.title === track.title)
                     const songIdx = trackSelectIdx ? trackSelectIdx.idx : 0;
                     const loading = loadingTracks && !(tracksLoaded.some(item => item === track.id))

--- a/apps/web/src/components/PlexPlaylist.tsx
+++ b/apps/web/src/components/PlexPlaylist.tsx
@@ -7,7 +7,7 @@ import { Track } from "@spotify-to-plex/shared-types/spotify/Track";
 import type { SearchResponse } from "@spotify-to-plex/plex-music-search/types/SearchResponse";
 import { Edit, Refresh, Search } from "@mui/icons-material";
 import CloseIcon from '@mui/icons-material/Close';
-import { Alert, Box, Button, CircularProgress, Divider, IconButton, Input, InputAdornment, Modal, Paper, Stack, TextField, Tooltip, Typography } from "@mui/material";
+import { Alert, Box, Button, CircularProgress, Dialog, Divider, IconButton, Input, InputAdornment, Modal, Paper, Stack, TextField, Tooltip, Typography } from "@mui/material";
 import axios from "axios";
 import { enqueueSnackbar } from "notistack";
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -36,7 +36,9 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
     const [page, setPage] = useState<number>(0);
     const [error, setError] = useState('')
     const [query, setQuery] = useState<string>('')
-    const [onlyUnresolved, setOnlyUnresolved] = useState<boolean>(false)
+    const [showReview, setShowReview] = useState<boolean>(false)
+    const reviewPageSize = 10;
+    const [reviewPage, setReviewPage] = useState<number>(0);
     const prevPageClick = useCallback(() => {
         setPage(prev => prev - 1)
     }, [])
@@ -54,9 +56,15 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
         setQuery('')
         setPage(0)
     }, [])
-    const onToggleUnresolved = useCallback(() => {
-        setOnlyUnresolved(prev => !prev)
-        setPage(0)
+    const onToggleReview = useCallback(() => {
+        setShowReview(prev => !prev)
+        setReviewPage(0)
+    }, [])
+    const reviewPrevPageClick = useCallback(() => {
+        setReviewPage(prev => prev - 1)
+    }, [])
+    const reviewNextPageClick = useCallback(() => {
+        setReviewPage(prev => prev + 1)
     }, [])
 
     ///////////////////////////////////////////////
@@ -339,17 +347,11 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
     // playlist rather than the current page
     const filteredTracks = useMemo(() => {
         const search = query.trim().toLowerCase();
-        if (!search && !onlyUnresolved)
+        if (!search)
             return playlist.tracks;
 
         return playlist.tracks.filter(track => {
             const data = findMatchFor(track)
-
-            if (onlyUnresolved && !!data && data.result.length === 1)
-                return false;
-
-            if (!search)
-                return true;
 
             const haystack: (string | undefined)[] = [track.title, track.album, ...track.artists];
             if (data)
@@ -359,9 +361,46 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
 
             return haystack.some(value => !!value && value.toLowerCase().includes(search));
         })
-    }, [playlist.tracks, findMatchFor, query, onlyUnresolved])
+    }, [playlist.tracks, findMatchFor, query])
 
-    const filtering = !!query.trim() || onlyUnresolved;
+    // Matched to more than one candidate - the rows worth a human look. Tracks with
+    // nothing at all are the missing-tracks dialog's job, and listing them in both
+    // is the same problem shown twice
+    const reviewTracks = useMemo(() =>
+        playlist.tracks.filter(track => {
+            const data = findMatchFor(track)
+
+            return !!data && data.result.length > 1
+        })
+    , [playlist.tracks, findMatchFor])
+
+    const reviewTotalPages = Math.ceil(reviewTracks.length / reviewPageSize)
+    const visibleReviewTracks = reviewTracks.slice(reviewPage * reviewPageSize, (reviewPage * reviewPageSize) + reviewPageSize)
+
+    // Resolving a track drops it from the list, which can empty the current page
+    useEffect(() => {
+        if (reviewPage > 0 && reviewPage >= reviewTotalPages)
+            setReviewPage(Math.max(0, reviewTotalPages - 1))
+    }, [reviewPage, reviewTotalPages])
+
+    const filtering = !!query.trim();
+
+    // Shared by the paged list and the review dialog so both stay interactive
+    const renderTrack = useCallback((track: Track) => {
+        const data = findMatchFor(track)
+        const trackSelectIdx = trackSelections.find(item => track.artists.indexOf(item.artist) > -1 && item.title === track.title)
+        const songIdx = trackSelectIdx ? trackSelectIdx.idx : 0;
+        const loading = loadingTracks && !(tracksLoaded.some(item => item === track.id))
+
+        return <PlexTrack
+            key={`${playlist.id}-plex-${track.title}-${track.id}}`}
+            loading={loading}
+            track={track}
+            setSongIdx={onSetSongIndex}
+            songIdx={songIdx}
+            data={data}
+        />
+    }, [findMatchFor, trackSelections, loadingTracks, tracksLoaded, onSetSongIndex, playlist.id])
     const totalPages = Math.ceil(filteredTracks.length / pageSize)
     const visibleTracks = filteredTracks.slice(page * pageSize, (page * pageSize) + pageSize)
     let curEnd = (page * pageSize) + pageSize;
@@ -387,10 +426,12 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
 
         return playlist.tracks
             .filter(item => {
-                return tracks.some(track => track.title === item.title && item.artists.indexOf(track.artist) > - 1 && track.result.length === 0)
+                const data = findMatchFor(item)
+
+                return !!data && data.result.length === 0
             })
 
-    }, [playlist, tracks])
+    }, [playlist, findMatchFor])
 
     if (error) {
         return (
@@ -494,6 +535,20 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
             </Box>
         }
 
+        {!!(reviewTracks.length > 0) && !loadingTracks &&
+            <Box sx={{ mt: 1, mb: 1 }}>
+                <Alert variant="outlined" severity="info">
+                    <Box sx={{ p: 1 }}>
+                        <Typography variant="h6" sx={{ mb: 0.5 }}>{reviewTracks.length} tracks to review</Typography>
+                        <Typography variant="body2" sx={{ mb: 1 }}>
+                            More than one track in your library matched these, so the wrong version may have been picked.
+                        </Typography>
+                        <Button variant="outlined" size="small" onClick={onToggleReview}>Review tracks</Button>
+                    </Box>
+                </Alert>
+            </Box>
+        }
+
         {missingTracks.length === 0 && !loadingTracks &&
             <Box sx={{ mt: 1, mb: 1 }}>
                 <Alert variant="outlined" color="success">
@@ -521,24 +576,20 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
 
             <Divider sx={{ mt: 1, mb: 1 }} />
             <Stack>
-                <Box display="flex" gap={1} mb={1}>
-                    <TextField
-                        size="small"
-                        fullWidth
-                        placeholder="Search this playlist"
-                        value={query}
-                        onChange={onQueryChange}
-                        InputProps={{
-                            startAdornment: <InputAdornment position="start"><Search fontSize="small" /></InputAdornment>,
-                            endAdornment: !!query && <InputAdornment position="end">
-                                <IconButton size="small" onClick={onClearQuery} aria-label="Clear search"><CloseIcon fontSize="small" /></IconButton>
-                            </InputAdornment>
-                        }}
-                    />
-                    <Tooltip title="Show only tracks that are missing or have more than one candidate">
-                        <Button variant={onlyUnresolved ? 'contained' : 'outlined'} onClick={onToggleUnresolved} sx={{ flexShrink: 0, whiteSpace: 'nowrap' }}>Needs review</Button>
-                    </Tooltip>
-                </Box>
+                <TextField
+                    size="small"
+                    fullWidth
+                    sx={{ mb: 1 }}
+                    placeholder="Search this playlist"
+                    value={query}
+                    onChange={onQueryChange}
+                    InputProps={{
+                        startAdornment: <InputAdornment position="start"><Search fontSize="small" /></InputAdornment>,
+                        endAdornment: !!query && <InputAdornment position="end">
+                            <IconButton size="small" onClick={onClearQuery} aria-label="Clear search"><CloseIcon fontSize="small" /></IconButton>
+                        </InputAdornment>
+                    }}
+                />
                 {!!filtering &&
                     <Typography variant="body2" sx={{ mb: 1, color: 'text.secondary' }}>
                         {filteredTracks.length === 0 ? 'No tracks match' : `${filteredTracks.length} of ${playlist.tracks.length} tracks`}
@@ -551,14 +602,7 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
                         <Button variant="contained" disabled={page >= totalPages - 1} onClick={nextPageClick}>Next</Button>
                     </Box>
                 }
-                {visibleTracks.map(track => {
-                    const data = findMatchFor(track)
-                    const trackSelectIdx = trackSelections.find(item => track.artists.indexOf(item.artist) > -1 && item.title === track.title)
-                    const songIdx = trackSelectIdx ? trackSelectIdx.idx : 0;
-                    const loading = loadingTracks && !(tracksLoaded.some(item => item === track.id))
-
-                    return <PlexTrack key={`${playlist.id}-plex-${track.title}-${track.id}}`} loading={loading} track={track} setSongIdx={onSetSongIndex} songIdx={songIdx} data={data} />
-                })}
+                {visibleTracks.map(renderTrack)}
             </Stack>
         </Paper>
 
@@ -578,6 +622,30 @@ export default function PlexPlaylist(props: PlexPlaylistProps) {
                     <Button variant="contained" onClick={onSavePlaylistNameClick} sx={{ mt: 2 }}>Save</Button>
                 </Box>
             </Modal>
+        }
+
+        {!!showReview &&
+            <Dialog open onClose={onToggleReview}>
+                <Box sx={{ maxWidth: 600, p: 2, position: 'relative' }}>
+                    <IconButton size="small" onClick={onToggleReview} sx={{ position: 'absolute', right: 8, top: 8 }}>
+                        <CloseIcon fontSize="small" />
+                    </IconButton>
+                    <Typography variant="h6">Tracks to review</Typography>
+                    <Typography variant="body2">
+                        Below you find the tracks where more than one track in your library matched. Pick the right one.
+                    </Typography>
+                    <Box sx={{ mt: 1 }}>
+                        {visibleReviewTracks.map(renderTrack)}
+
+                        {reviewTotalPages > 1 &&
+                            <Box mt={1} display="flex" justifyContent="space-between">
+                                <Button size="small" variant="outlined" color="inherit" disabled={reviewPage <= 0} onClick={reviewPrevPageClick}>Previous</Button>
+                                <Button size="small" variant="outlined" color="inherit" disabled={reviewPage >= reviewTotalPages - 1} onClick={reviewNextPageClick}>Next</Button>
+                            </Box>
+                        }
+                    </Box>
+                </Box>
+            </Dialog>
         }
 
         {!!showExportMissingTracks && missingTracks.length > 0 &&


### PR DESCRIPTION
Two related additions to the playlist view, for the same problem: on a long playlist there is no way to find a particular track.

### Search

The list pages 30 at a time with no filter, so reaching a specific track on a 463-track playlist means clicking through pages. This adds a search box that filters the whole playlist, not the current page.

That turns out to need no API change at all. The loader is not page-scoped — it fetches cached matches for every track, then searches the rest in batches — so by the time the list renders, every track and its match state is already in the browser. Search is a pure client-side filter over data that is already there.

It matches on the Spotify title, album and artists, **and on the title, artist and album of whatever it matched in Plex**. That second part is deliberate: it lets you search for the wrong result to find the tracks that picked it up. Searching an artist's name surfaces tracks mistakenly matched to them.

Page count, range and the empty state all derive from the filtered list; changing the filter resets to page 1, and the page is clamped if results shrink while tracks are still resolving.

### Tracks to review

A track that matched more than one library track is silently resolved to the first one, and there is no way to find those rows. A banner now states the count and opens a dialog listing them.

It follows the existing missing-tracks dialog deliberately — same 600px box, same heading treatment, same ten-per-page pager — so the two read as one feature rather than two designs. The rows in it are the same track rows as the list, so the candidate picker still works from inside the dialog.

Missing tracks stay with the missing-tracks dialog rather than appearing in both. The two need different things done to them: one wants acquiring, the other wants choosing between candidates. Counting a track in both just shows the same problem twice.

### Notes

- The result lookup shared by the filter, the row renderer and the missing-track count is now a single helper. It previously existed twice with slightly different rules — the missing count lacked the merged-artist fallback the row lookup had, so a track matched under a merged artist string was not counted as missing even with no result.
- `type-check` and `eslint` are clean. Worth mentioning that neither runs during the Docker build (`ignoreBuildErrors` is set when `NEXT_DOCKER=1`), so `pnpm --filter @spotify-to-plex/web run type-check` has to be run separately — it caught real errors for me that a green image build did not.

### Screenshots of what it looks like
<img width="1062" height="622" alt="Screenshot 2026-08-29 at 1 11 14 am" src="https://github.com/user-attachments/assets/6cb604e5-7e57-4a11-b8a0-1b2ddcd21348" />

<img width="596" height="791" alt="Screenshot 2026-08-29 at 1 09 26 am" src="https://github.com/user-attachments/assets/65594af0-4e88-41f3-ad4c-f9366f5672b8" />


