### PR TITLE
chore: tidy the album-expansion and enrichment-fallback merges

### DIFF
--- a/packages/plex-music-search/src/utils/searching/searchForTrack.ts
+++ b/packages/plex-music-search/src/utils/searching/searchForTrack.ts
@@ -40,6 +40,7 @@ export async function searchForTrack(uri: string, token: string, artist: string,
     // search index can miss tracks whose album IS indexed, and album hits often
     // only surface on the title-only query
     const albums = searchResult.filter(item => item.type == "album");
+
     for (const album of albums.slice(0, 3)) {
         try {
             const trackResult: HubSearchResult[] = await getAlbumTracks(uri, token, album.id)

--- a/packages/shared-utils/src/spotify/getSpotifyData.ts
+++ b/packages/shared-utils/src/spotify/getSpotifyData.ts
@@ -190,6 +190,13 @@ export async function getSpotifyData(api: SpotifyApi, id: string, simplified: bo
                     batchError.message?.includes('rate limit') ||
                     batchError.message?.includes('429');
 
+                // Restricted-mode (development) apps get 403 on the batch endpoint
+                // while the single-track endpoint keeps working
+                const isForbidden = batchError.status === 403 ||
+                    batchError.statusCode === 403 ||
+                    batchError.message?.includes('403') ||
+                    batchError.message?.includes('Forbidden');
+
                 if (isRateLimit) {
                     // Extract retry-after from various possible locations
                     const retryAfter = parseInt(
@@ -205,13 +212,19 @@ export async function getSpotifyData(api: SpotifyApi, id: string, simplified: bo
 
                     console.log(`Rate limited. Waiting ${backoffDelay}ms before retry ${retryCount}/${MAX_RETRIES}...`);
                     await new Promise(resolve => { setTimeout(resolve, backoffDelay) });
-                } else {
+                } else if (isForbidden) {
                     // Batch /v1/tracks?ids= is 403-forbidden for restricted-mode tokens
-                    // while single-track lookups still work - enrich one by one instead
-                    console.error(`Error enriching batch - ${retryCount}/${MAX_RETRIES}: ${batchError.message}. Falling back to single-track lookups.`);
+                    // while single-track lookups still work - enrich one by one instead.
+                    // Only 403 falls back: any other error is likely transient, and
+                    // retrying it as 50 single calls would just multiply the failure
+                    console.error(`Batch enrichment forbidden - ${retryCount}/${MAX_RETRIES}: ${batchError.message}. Falling back to single-track lookups.`);
                     const enrichedBatch = await enrichTracksIndividually(api, batch, BATCH_DELAY);
                     tracks.splice(i, BATCH_SIZE, ...enrichedBatch);
                     success = true;
+                } else {
+                    // For other errors, just log and continue with original track data
+                    console.error(`Error enriching batch - ${retryCount}/${MAX_RETRIES}: ${batchError.message}`);
+                    success = true; // Don't retry non-rate-limit errors
                 }
             }
         }


### PR DESCRIPTION
Follow-up to #129 and #131, both merged as their authors wrote them. Neither could be fixed on the branch — they come from a fork.

- **`searchForTrack`** — blank line before the album-expansion loop, so the file passes `padding-line-between-statements` again. Main currently has one lint error; this is it.
- **`getSpotifyData`** — only a **403** now falls back to single-track lookups. As merged, the fallback fired on any non-429 error, which turns one transient failure into 50 sequential requests at 350ms each (~17s per batch). A restricted-mode token is specifically what 403 signals, so match on that and keep the original log-and-continue for everything else.

Verified: `tsc --noEmit` clean across all packages, web and sync-worker; `eslint` clean on both files (only pre-existing `no-console` warnings remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtxHSMRx5hRs5r1u2ZYFyX