### PR TITLE
feat: add version and duration as match filter fields

### DIFF
--- a/apps/web/src/components/popups/FieldSelectorPopup.tsx
+++ b/apps/web/src/components/popups/FieldSelectorPopup.tsx
@@ -22,7 +22,9 @@ const FieldSelectorPopup: React.FC<FieldSelectorPopupProps> = ({
         { value: 'title', label: 'Title', description: 'Match by track title' },
         { value: 'album', label: 'Album', description: 'Match by album name' },
         { value: 'artistWithTitle', label: 'Artist with Title', description: 'Match by artist and title combined' },
-        { value: 'artistInTitle', label: 'Artist in Title', description: 'Match artist name within track title' }
+        { value: 'artistInTitle', label: 'Artist in Title', description: 'Match artist name within track title' },
+        { value: 'version', label: 'Version', description: 'Both titles name the same version (remix, edit, acoustic)' },
+        { value: 'duration', label: 'Duration', description: 'Match by track length (similarity only)' }
     ];
 
     const createFieldClickHandler = useCallback((field: FieldType) => () => {

--- a/apps/web/src/types/MatchFilterTypes.ts
+++ b/apps/web/src/types/MatchFilterTypes.ts
@@ -5,7 +5,7 @@
 export type MatchFilterRule = string; // e.g., "artist:match AND title:match"
 
 // Expression parsing types
-export type FieldType = 'artist' | 'title' | 'album' | 'artistWithTitle' | 'artistInTitle';
+export type FieldType = 'artist' | 'title' | 'album' | 'artistWithTitle' | 'artistInTitle' | 'version' | 'duration';
 export type OperationType = 'match' | 'contains' | 'similarity' | 'is' | 'not';
 export type OperationText = OperationType | `similarity>=${number}`;
 export type CombinatorType = 'AND' | 'OR';

--- a/apps/web/src/utils/expressionToPills.ts
+++ b/apps/web/src/utils/expressionToPills.ts
@@ -50,7 +50,7 @@ export function expressionToPills(expression: string): Pill[] {
                 });
             } else {
                 // Check if this is just a field name without operation
-                const fieldOnlyPattern = /^(artist|title|album|artistWithTitle|artistInTitle)$/;
+                const fieldOnlyPattern = /^(artist|title|album|artistWithTitle|artistInTitle|version|duration)$/;
                 const fieldMatch = fieldOnlyPattern.exec(token);
                 
                 if (fieldMatch) {
@@ -78,7 +78,7 @@ export function expressionToPills(expression: string): Pill[] {
 
 function parseCondition(conditionText: string): ParsedCondition | null {
     // Match pattern: field:operation or field:operation>=threshold
-    const conditionPattern = /^(artist|title|album|artistWithTitle|artistInTitle):(match|contains|similarity(?:>=\d*\.?\d+)?)$/;
+    const conditionPattern = /^(artist|title|album|artistWithTitle|artistInTitle|version|duration):(match|contains|similarity(?:>=\d*\.?\d+)?)$/;
     const match = conditionPattern.exec(conditionText);
     
     if (!match) {

--- a/packages/music-search/src/functions/parseExpression.ts
+++ b/packages/music-search/src/functions/parseExpression.ts
@@ -21,7 +21,7 @@ type ParsedExpression = {
 /**
  * Safely parse expression syntax into executable filter function
  * Expression format: "artist:match AND title:contains"
- * Supported fields: artist, title, album, artistWithTitle, artistInTitle
+ * Supported fields: artist, title, album, artistWithTitle, artistInTitle, version, duration
  * Supported operations: :match, :contains, :is, :not, :similarity>=threshold
  * Supported combinators: AND, OR
  */
@@ -94,7 +94,7 @@ function parseCondition(conditionStr: string): ParsedCondition {
     }
 
     // Validate field
-    const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle'];
+    const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle', 'version', 'duration'];
 
     if (!validFields.includes(field)) {
         throw new Error(`Invalid field: ${field}`);
@@ -217,6 +217,16 @@ function getMatchingField(item: Track, field: string) {
             return item.matching.artistWithTitle;
         case 'artistInTitle':
             return item.matching.artistInTitle;
+        case 'version':
+            return item.matching.version ?? null;
+        case 'duration': {
+            // Only :similarity is meaningful here. A missing duration on either
+            // side scores 0, so a duration-guarded row fails closed and the
+            // later rows still get their turn
+            const { duration } = item.matching;
+
+            return duration ? { match: false, contains: false, similarity: duration.similarity } : null;
+        }
         default:
             return null;
     }

--- a/packages/music-search/src/functions/search.ts
+++ b/packages/music-search/src/functions/search.ts
@@ -1,6 +1,7 @@
 import { Track } from "../types/Track";
 import { compareTitles } from '@spotify-to-plex/shared-utils/music/compareTitles';
 import { removeFeaturing } from '@spotify-to-plex/shared-utils/music/removeFeaturing';
+import { compareVersions } from "../utils/compareVersions";
 import { getRuntimeFilters } from "./getRuntimeFilters";
 
 export function search(find: Track, options: Track[], analyze: boolean = false) {
@@ -23,6 +24,7 @@ export function search(find: Track, options: Track[], analyze: boolean = false) 
                 artistWithTitle: compareTitles(item.title, `${find.artist} ${find.title}`, true),
                 artist: compareTitles(item.artist, find.artist, true),
                 alternativeArtist: compareTitles(removeFeaturing(item.artist), find.artist, true),
+                version: compareVersions(item.title, find.title),
                 duration: { similarity: durationSimilarity, available: hasBothDurations },
             };
 

--- a/packages/music-search/src/types/Track.ts
+++ b/packages/music-search/src/types/Track.ts
@@ -12,6 +12,7 @@ export type Track = {
         artist: { match: boolean; contains: boolean; similarity: number; };
         artistInTitle: { match: boolean; contains: boolean; similarity: number; };
         artistWithTitle: { match: boolean; contains: boolean; similarity: number; };
+        version?: { match: boolean; contains: boolean; similarity: number; };
         duration?: { similarity: number; available: boolean; };
         isMatchingApproach?:boolean;
     };

--- a/packages/music-search/src/utils/compareVersions.ts
+++ b/packages/music-search/src/utils/compareVersions.ts
@@ -1,0 +1,89 @@
+import { getState } from "../functions/state/getState";
+
+// "(radio edit)", "[live]", "{dub}" and the trailing " - Radio Edit" form Spotify uses
+const BRACKETED = /\(([^)]*)\)|\[([^\]]*)]|{([^}]*)}/g;
+const TRAILING_DASH = /\s-\s(.+)$/;
+
+// "(feat. X)", "(with X)", "(& X)" - a credit, not a version of the recording
+const CREDIT = /^(?:feat|feats|featuring|ft|with|w)\b|^[&+]/;
+// "From \"8 Mile\" Soundtrack" - provenance, not a version
+const PROVENANCE = /^from\b/;
+const YEAR = /\b(?:19|20)\d{2}\b/g;
+
+// Qualifiers that name no particular version. Longest first so "main mix" is
+// removed whole rather than leaving a bare "mix" behind
+const STRUCTURAL = ['album version', 'bonus track', 'main mix', 'radio mix', 'main', 'deluxe', 'explicit', 'clean', 'mono', 'stereo'];
+
+// A fragment shorter than this carries no version meaning on its own
+const MIN_QUALIFIER_LENGTH = 3;
+
+function escapeForRegex(word: string) {
+    return word.replace(/[$()*+.?[\\\]^{|}]/g, String.raw`\$&`);
+}
+
+/**
+ * Remove a noise word, but only where it stands as a whole word. Removing it as
+ * a plain substring would eat the middle of real words - "main" out of
+ * "Germaine", "clean" out of "cleaner" - and silently invent a version match
+ */
+function removeWord(text: string, word: string) {
+    const pattern = new RegExp(String.raw`\b${escapeForRegex(word.toLowerCase())}\b`, 'g');
+
+    return text.replace(pattern, ' ');
+}
+
+/**
+ * The version qualifier of a title - "acoustic", "jauz remix", "uk edit" - or ''
+ * when the title names no particular version. Credits, provenance and words the
+ * user treats as noise are not version distinctions.
+ */
+export function extractVersion(title: string, filterOutWords: string[]): string {
+    const segments: string[] = [];
+
+    for (const match of title.matchAll(BRACKETED))
+        segments.push(match[1] ?? match[2] ?? match[3] ?? '');
+
+    const trailing = TRAILING_DASH.exec(title.replace(BRACKETED, ''));
+    if (trailing?.[1])
+        segments.push(trailing[1]);
+
+    const meaningful = segments
+        .map(segment => segment.toLowerCase().trim())
+        .filter(segment => !CREDIT.test(segment) && !PROVENANCE.test(segment))
+        .map(segment => {
+            let result = segment;
+
+            for (const word of [...filterOutWords, ...STRUCTURAL])
+                result = removeWord(result, word);
+
+            return result
+                .replace(YEAR, ' ')
+                .replace(/[^\d a-z]/g, '')
+                .replace(/\s+/g, ' ')
+                .trim();
+        })
+        .filter(segment => segment.length >= MIN_QUALIFIER_LENGTH);
+
+    return meaningful.join(' ');
+}
+
+/**
+ * Whether two titles name the same version. Duration cannot separate two
+ * different remixes of equal length, so this compares what the titles claim.
+ */
+export function compareVersions(a?: string, b?: string) {
+    if (!a || !b)
+        return { match: false, contains: false, similarity: 0 };
+
+    const filterOutWords = getState().musicSearchConfig?.textProcessing?.filterOutWords ?? [];
+    const versionA = extractVersion(a, filterOutWords);
+    const versionB = extractVersion(b, filterOutWords);
+
+    const match = versionA === versionB;
+
+    // One side naming a version the other does not is the mismatch worth
+    // catching: "Language" offered for "Language - UK Edit"
+    const contains = !!versionA && !!versionB && (versionA.includes(versionB) || versionB.includes(versionA));
+
+    return { match, contains, similarity: match ? 1 : 0 };
+}

--- a/packages/shared-utils/src/validation/validateExpression.ts
+++ b/packages/shared-utils/src/validation/validateExpression.ts
@@ -16,14 +16,15 @@ export function validateExpression(expression: string): ValidationResult {
         }
         
         // Validate field names - check both standalone fields and fields with operations
-        const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle'];
+        // Must stay in sync with parseExpression's validFields (music-search)
+        const validFields = ['artist', 'title', 'album', 'artistWithTitle', 'artistInTitle', 'version', 'duration'];
         
         // Extract fields with operations
         const fieldWithOpRegex = /([A-Za-z]+):/g;
         const fieldsWithOps = Array.from(expression.matchAll(fieldWithOpRegex), m => m[1]);
         
         // Extract standalone fields (not followed by colon)
-        const standaloneFieldRegex = /\b(artist|title|album|artistWithTitle|artistInTitle)\b(?!:)/g;
+        const standaloneFieldRegex = /\b(artist|title|album|artistWithTitle|artistInTitle|version|duration)\b(?!:)/g;
         const standaloneFields = Array.from(expression.matchAll(standaloneFieldRegex), m => m[1]);
         
         // Combine and validate all fields


### PR DESCRIPTION
Combines #128 (duration) and #135 (version) by @chodeus. Both added the same field list in the same five files, so they conflicted with each other and only one could ever have been merged as-is.

**Neither changes matching on its own.** `DEFAULT_MATCH_FILTERS` is untouched, so existing installs behave exactly as before until someone opts a row in:

```
artist:match AND title:match AND version:match
artist:match AND title:match AND duration:similarity>=0.65
```

### duration
`search()` already computes a duration similarity but only uses it as a half-weighted tie-breaker in the sort, so no filter row could veto on it — an 8:42 album cut could satisfy a row asking for a 3:03 single.

### version
Compares what two titles *claim* about the recording, which duration cannot: two remixes of one song are usually the same length. `extractVersion` takes the qualifier from a title and discards what is not a version distinction — featured-artist credits, provenance, years, structural words, and the user's own `filterOutWords`.

### Changed from #135
Noise words are removed on **word boundaries** rather than as raw substrings. The original `split(word).join(' ')` ate the middle of real words:

| Title | #135 | This PR |
|---|---|---|
| `Germaine Remix` | `ger e remix` | `germaine remix` |
| `Cleaner Mix` | `er mix` | `cleaner mix` |
| `Monotone Dub` | `tone dub` | `monotone dub` |

That invents version differences where there are none, which for a `version:match` guard means rejecting correct matches.

Both fields fail closed: an absent duration or version scores 0, so a guarded row rejects and the later rows still apply.

### Verification
- `tsc --noEmit` clean across all packages, web and sync-worker
- `eslint` clean on every changed file
- `extractVersion` exercised against 15 cases (the six mismatches from #135's own write-up, the credit/provenance/year/structural cases, and the three substring cases above — all as expected. The repo has no test framework, so these were run ad-hoc rather than committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtxHSMRx5hRs5r1u2ZYFyX
EOF
)