### PR TITLE
Accept version and duration in match filter validation

### DIFF
--- a/apps/web/pages/advanced/music-search-config/match-filters.tsx
+++ b/apps/web/pages/advanced/music-search-config/match-filters.tsx
@@ -36,7 +36,7 @@ const MatchFiltersPage: NextPage = () => {
             }
 
             // Basic expression validation - allow optional operations
-            const validFieldPattern = /^(artist|title|album|artistWithTitle|artistInTitle)(:(match|contains|similarity>=\d*\.?\d+))?((\s+(AND|OR)\s+(artist|title|album|artistWithTitle|artistInTitle)(:(match|contains|similarity>=\d*\.?\d+))?))*$/;
+            const validFieldPattern = /^(artist|title|album|artistWithTitle|artistInTitle|version|duration)(:(match|contains|similarity>=\d*\.?\d+))?((\s+(AND|OR)\s+(artist|title|album|artistWithTitle|artistInTitle|version|duration)(:(match|contains|similarity>=\d*\.?\d+))?))*$/;
             if (!validFieldPattern.test(filter.trim())) {
                 return `Filter at index ${i}: invalid expression format`;
             }
@@ -124,7 +124,7 @@ const MatchFiltersPage: NextPage = () => {
         items: {
             type: 'string',
             description: 'Expression string using simplified syntax (e.g., "artist:match AND title:contains")',
-            pattern: String.raw`^(artist|title|album|artistWithTitle|artistInTitle):(match|contains|similarity>=\d*\.?\d+)(\s+(AND|OR)\s+(artist|title|album|artistWithTitle|artistInTitle):(match|contains|similarity>=\d*\.?\d+))*$`
+            pattern: String.raw`^(artist|title|album|artistWithTitle|artistInTitle|version|duration):(match|contains|similarity>=\d*\.?\d+)(\s+(AND|OR)\s+(artist|title|album|artistWithTitle|artistInTitle|version|duration):(match|contains|similarity>=\d*\.?\d+))*$`
         }
     };
 

--- a/apps/web/pages/api/plex/music-search-config/match-filters.ts
+++ b/apps/web/pages/api/plex/music-search-config/match-filters.ts
@@ -78,7 +78,7 @@ function validateExpressions(filters: MatchFilterConfig[]) {
         }
 
         // Basic expression validation - allow both complete (field:operation) and incomplete (field) conditions
-        const fieldPattern = '(artist|title|album|artistWithTitle|artistInTitle)';
+        const fieldPattern = '(artist|title|album|artistWithTitle|artistInTitle|version|duration)';
         const operationPattern = String.raw`:(match|contains|similarity>=\d*\.?\d+)`;
         const conditionPattern = `${fieldPattern}(${operationPattern})?`; // Operation is optional
         const validPattern = new RegExp(String.raw`^${conditionPattern}(\s+(AND|OR)\s+${conditionPattern})*$`);


### PR DESCRIPTION
#138 added `version` and `duration` to the field selector, but three copies of the field list still carry the old set, so picking either field and saving fails:

- `pages/advanced/music-search-config/match-filters.tsx:39` — client validator, "invalid expression format"
- `pages/api/plex/music-search-config/match-filters.ts:81` — server validator, 400
- `pages/advanced/music-search-config/match-filters.tsx:127` — JSON-editor schema

Editing `match-filters.json` by hand was the only way in.

`duration:similarity>=0.65` and `version:match` fail all three gates before this change and pass after; `bogus:match`, `durations:match` and `versionx:match` are still rejected.

The field list now lives in eight places. A single exported constant would be the real fix.
