### PR TITLE
Wire slskd-music-search into the build graph

### DIFF
--- a/apps/sync-worker/tsconfig.json
+++ b/apps/sync-worker/tsconfig.json
@@ -45,6 +45,9 @@
       "path": "../../packages/tidal-music-search"
     },
     {
+      "path": "../../packages/slskd-music-search"
+    },
+    {
       "path": "../../packages/plex-helpers"
     }
   ]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@spotify-to-plex/plex-music-search": "workspace:*",
     "@spotify-to-plex/shared-types": "workspace:*",
     "@spotify-to-plex/shared-utils": "workspace:*",
+    "@spotify-to-plex/slskd-music-search": "workspace:*",
     "@spotify-to-plex/tidal-music-search": "workspace:*",
     "@spotify/web-api-ts-sdk": "^1.2.0",
     "axios": "^1.11.0",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -84,6 +84,9 @@
       "path": "../../packages/tidal-music-search"
     },
     {
+      "path": "../../packages/slskd-music-search"
+    },
+    {
       "path": "../sync-worker"
     }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@spotify-to-plex/shared-utils':
         specifier: workspace:*
         version: link:../../packages/shared-utils
+      '@spotify-to-plex/slskd-music-search':
+        specifier: workspace:*
+        version: link:../../packages/slskd-music-search
       '@spotify-to-plex/tidal-music-search':
         specifier: workspace:*
         version: link:../../packages/tidal-music-search

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "./packages/tidal-music-search"
     },
     {
+      "path": "./packages/slskd-music-search"
+    },
+    {
       "path": "./packages/plex-helpers"
     },
     {
@@ -54,6 +57,8 @@
       "@spotify-to-plex/plex-music-search/*": ["./packages/plex-music-search/src/*"],
       "@spotify-to-plex/tidal-music-search": ["./packages/tidal-music-search/src"],
       "@spotify-to-plex/tidal-music-search/*": ["./packages/tidal-music-search/src/*"],
+      "@spotify-to-plex/slskd-music-search": ["./packages/slskd-music-search/src"],
+      "@spotify-to-plex/slskd-music-search/*": ["./packages/slskd-music-search/src/*"],
       "@spotify-to-plex/plex-config": ["./packages/plex-config/src"],
       "@spotify-to-plex/plex-config/*": ["./packages/plex-config/src/*"],
       "@spotify-to-plex/plex-helpers": ["./packages/plex-helpers/src"],


### PR DESCRIPTION
`apps/web` and `apps/sync-worker` both import `@spotify-to-plex/slskd-music-search`, but it appears in no tsconfig reference list and `apps/web` never declared it. `tsc --build` therefore never builds it, so a clean clone of `main` fails:

```
pnpm run build        21 errors
pnpm run type-check    2 errors
```

TS2307 in `pages/api/slskd/*` and `jobs/slskd.ts`, plus the implicit-any errors that follow from them. Both are 0 after this, including under `--frozen-lockfile`.

Only `build:packages` ever built the package, because it globs `packages/*` — which is why the Docker image is fine and the repo scripts are not.

The package is now wired in the same six places as `plex-music-search` and `tidal-music-search`.
