### PR TITLE
fix: page Spotify playlists past the first 100 tracks

### DIFF
--- a/packages/shared-utils/src/spotify/getSpotifyPlaylist.test.ts
+++ b/packages/shared-utils/src/spotify/getSpotifyPlaylist.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSpotifyPlaylist } from './getSpotifyPlaylist';
+
+const TOTAL = 250;
+
+function track(index: number) {
+    return {
+        track: {
+            id: `track-${index}`,
+            name: `Track ${index}`,
+            uri: `spotify:track:${index}`,
+            artists: [{ name: 'Artist A, Artist B' }],
+            album: { id: 'album-1', name: 'Album' },
+            duration_ms: 1000 + index
+        }
+    };
+}
+
+function fakeApi(total: number) {
+    const requests: { limit: number; offset: number }[] = [];
+
+    const api = {
+        playlists: {
+            getPlaylist: async () => ({
+                id: 'playlist-1',
+                name: 'Playlist',
+                owner: { display_name: 'Owner' },
+                images: [{ url: 'image.jpg' }],
+                tracks: {
+                    total,
+                    items: Array.from({ length: Math.min(100, total) }, (_v, i) => track(i))
+                }
+            }),
+            getPlaylistItems: async (_id: string, _market: unknown, _fields: unknown, limit: number, offset: number) => {
+                requests.push({ limit, offset });
+
+                return {
+                    total,
+                    items: Array.from({ length: Math.max(0, Math.min(limit, total - offset)) }, (_v, i) => track(offset + i))
+                };
+            }
+        }
+    };
+
+    return { api, requests };
+}
+
+describe('getSpotifyPlaylist', () => {
+    it('pages past the first 100 tracks', async () => {
+        const { api, requests } = fakeApi(TOTAL);
+        const playlist = await getSpotifyPlaylist(api as any, 'playlist-1', false);
+
+        expect(playlist?.tracks).toHaveLength(TOTAL);
+        expect(playlist?.tracks.at(-1)?.id).toBe(`track-${TOTAL - 1}`);
+        expect(playlist?.tracks[0]?.artists).toEqual(['Artist A', 'Artist B']);
+        expect(requests[0]).toEqual({ limit: 50, offset: 100 });
+    }, 30_000);
+
+    it('stops at 500 tracks', async () => {
+        const { api } = fakeApi(1200);
+        const playlist = await getSpotifyPlaylist(api as any, 'playlist-1', false);
+
+        expect(playlist?.tracks).toHaveLength(500);
+        expect(playlist?.tracks.at(-1)?.id).toBe('track-499');
+    }, 30_000);
+
+    it('stops at the first page when simplified', async () => {
+        const { api, requests } = fakeApi(TOTAL);
+        const playlist = await getSpotifyPlaylist(api as any, 'playlist-1', true);
+
+        expect(playlist?.tracks).toHaveLength(100);
+        expect(requests).toHaveLength(0);
+    });
+});

--- a/packages/shared-utils/src/spotify/getSpotifyPlaylist.ts
+++ b/packages/shared-utils/src/spotify/getSpotifyPlaylist.ts
@@ -1,12 +1,43 @@
 import { GetSpotifyPlaylist } from "@spotify-to-plex/shared-types/spotify/GetSpotifyPlaylist";
-import { Page, PlaylistedTrack, SpotifyApi, Track } from "@spotify/web-api-ts-sdk";
+import { MaxInt, Page, PlaylistedTrack, SpotifyApi, Track } from "@spotify/web-api-ts-sdk";
 
+const PAGE_SIZE = 50;
+// ponytail: hard cap on how many tracks a playlist contributes; raise if bigger playlists matter
+const MAX_TRACKS = 500;
+// ~350ms delay = ~171 requests/minute (under the ~180 req/min limit with safety margin)
+const PAGE_DELAY = 350;
+
+function mapTracks(items: PlaylistedTrack<Track>[]) {
+    return items
+        .map(item => {
+            // The 2024 API change exposes the track as `item`; older responses use `track`.
+            const track: Track | undefined = (item as any).item ?? (item as any).track;
+            if (!track || typeof track !== 'object')
+                return null;
+
+            // Local files have no id but do have a spotify:local: uri
+            if (!track.id && !track.uri)
+                return null;
+
+            const artists = track.artists?.flatMap(artist => artist.name.split(',').map(name => name.trim()));
+
+            return {
+                id: track.id || track.uri,
+                title: track.name,
+                artist: track.artists?.[0]?.name || 'Unknown',
+                album: track.album?.name || 'Unknown',
+                artists: artists || [],
+                album_id: track.album?.id || 'unknown',
+                duration_ms: track.duration_ms
+            }
+        })
+        .filter((track) => !!track);
+}
 
 export async function getSpotifyPlaylist(api: SpotifyApi, id: string, simplified: boolean) {
 
 
     try {
-        const tokenInfo = await api.getAccessToken();
         const result = await api.playlists.getPlaylist(id)
         const playlist: GetSpotifyPlaylist = {
             type: "spotify-playlist",
@@ -19,8 +50,7 @@ export async function getSpotifyPlaylist(api: SpotifyApi, id: string, simplified
 
         // Spotify Web API change (rolled out late 2024): user-authenticated
         // /playlists/{id} responses now return the tracks page under `items`
-        // instead of `tracks`, and each entry exposes the track object as
-        // `item` instead of `track`. Read both shapes so the function keeps
+        // instead of `tracks`. Read both shapes so the function keeps
         // working for any account or region still on the legacy response.
         // Pick whichever field actually holds a page of tracks: `??` alone would
         // take an `items` field that is present but not a tracks page, and skip
@@ -34,82 +64,28 @@ export async function getSpotifyPlaylist(api: SpotifyApi, id: string, simplified
             return null;
         }
 
-        const validTracks = tracksPage.items
-            .map(item => {
-                const track: Track | undefined = (item as any).item ?? (item as any).track;
-                if (!track || typeof track !== 'object')
-                    return null;
-
-                // Local files have no id but do have a spotify:local: uri
-                if (!track.id && !track.uri)
-                    return null;
-
-                const artists = track.artists?.flatMap(artist => artist.name.split(',').map(name => name.trim()));
-
-                return {
-                    id: track.id || track.uri,
-                    title: track.name,
-                    artist: track.artists?.[0]?.name || 'Unknown',
-                    album: track.album?.name || 'Unknown',
-                    artists: artists || [],
-                    album_id: track.album?.id || 'unknown',
-                    duration_ms: track.duration_ms
-                }
-            })
-            .filter((track) => !!track);
-
-        playlist.tracks = playlist.tracks.concat(validTracks);
+        playlist.tracks = mapTracks(tracksPage.items);
         if (simplified)
             return playlist;
 
-        let nextUrl: string | null = tracksPage.next
-        while (nextUrl) {
+        // The embedded page only carries the first 100 tracks, so keep asking the
+        // items endpoint for the rest, up to MAX_TRACKS. Paging by offset instead
+        // of following `next` by hand keeps the SDK's auth: a manual fetch needs a
+        // token this function does not always have.
+        let offset = tracksPage.items.length;
+        const total = Math.min(typeof tracksPage.total === 'number' ? tracksPage.total : Infinity, MAX_TRACKS);
 
-            const response = await fetch(nextUrl, {
-                headers: {
-                    'Authorization': `Bearer ${tokenInfo?.access_token}`
-                }
-            });
+        while (offset < total) {
+            await new Promise(resolve => { setTimeout(resolve, PAGE_DELAY) });
 
-            if (!response.ok) {
-                console.error(`❌ Fetch failed: ${response.status} ${response.statusText}`);
+            const limit = Math.min(PAGE_SIZE, total - offset) as MaxInt<50>;
+            const page = await api.playlists.getPlaylistItems(id, undefined, undefined, limit, offset);
+            const items = page?.items;
+            if (!items?.length)
                 break;
-            }
 
-            const data = await response.json();
-            const loadMore = data as Page<PlaylistedTrack<Track>>;
-            if (!loadMore.items) {
-                nextUrl = null;
-                break;
-            }
-
-            const validLoadMoreTracks = loadMore.items
-                .map(item => {
-                    const track: Track | undefined = (item as any).item ?? (item as any).track;
-                    if (!track || typeof track !== 'object') return null;
-
-                    // Local files have no id but do have a spotify:local: uri
-                    if (!track.id && !track.uri)
-                        return null;
-
-                    return {
-                        id: track.id || track.uri,
-                        title: track.name,
-                        artist: track.artists?.[0]?.name || 'Unknown',
-                        album: track.album?.name || 'Unknown',
-                        artists: track.artists?.map(artist => artist.name) || [],
-                        album_id: track.album?.id || 'unknown',
-                        duration_ms: track.duration_ms
-                    }
-                })
-                .filter((track) => !!track);
-
-            playlist.tracks = playlist.tracks.concat(validLoadMoreTracks);
-
-            nextUrl = loadMore.next
-
-            if (nextUrl)
-                await new Promise(resolve => { setTimeout(resolve, 350) });
+            playlist.tracks = playlist.tracks.concat(mapTracks(items));
+            offset += items.length;
         }
 
         return playlist;


### PR DESCRIPTION
Playlist fetches stopped at 100 tracks: after the page embedded in the /playlists/{id} response, pagination followed `next` with a manual fetch whose Bearer token came from api.getAccessToken(). When that token was missing or the request failed, the loop broke and the caller silently got only the first page.

Page through api.playlists.getPlaylistItems() by offset instead, so the SDK handles auth, and cap a playlist at 500 tracks. The duplicated track mapping is now a single mapTracks() helper, which also makes the later pages split comma-separated artist names like the first page already did.
